### PR TITLE
GtkRecentInfo: use time_t for arguments instead, and cast results to i64.

### DIFF
--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -100,8 +100,8 @@ impl RecentInfo {
             let mut time_ = 0;
 
             match to_bool(ffi::gtk_recent_info_get_application_info(
-                GTK_RECENT_INFO(self.unwrap_widget()), app_name.borrow_to_glib().0,
-                &mut app_exec, &mut count, &mut time_)) {
+                    GTK_RECENT_INFO(self.unwrap_widget()), app_name.borrow_to_glib().0,
+                    &mut app_exec, &mut count, &mut time_)) {
                 true => Some((FromGlibPtrNotNull::borrow(app_exec), count, time_ as u64)),
                 _ => None
             }

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -27,10 +27,9 @@ impl RecentInfo {
     pub fn _ref(&self) -> Option<RecentInfo> {
         let tmp_pointer = unsafe { ffi::gtk_recent_info_ref(GTK_RECENT_INFO(self.unwrap_widget())) };
 
-        if tmp_pointer.is_null() {
-            None
-        } else {
-            Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget))
+        match tmp_pointer.is_null() {
+            false => Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget)),
+            _ => None
         }
     }
 
@@ -91,26 +90,17 @@ impl RecentInfo {
         unsafe { to_bool(ffi::gtk_recent_info_get_private_hint(GTK_RECENT_INFO(self.unwrap_widget()))) }
     }
 
-    pub fn get_application_info(&self, app_name: &str) -> Option<(String, u32, i64)> {
+    pub fn get_application_info(&self, app_name: &str) -> Option<(String, u32, u64)> {
         unsafe {
             let mut app_exec = ptr::null();
             let mut count = 0;
             let mut time_ = 0;
 
-            let ret = to_bool(
-                ffi::gtk_recent_info_get_application_info(
-                    GTK_RECENT_INFO(self.unwrap_widget()),
-                    app_name.borrow_to_glib().0,
-                    &mut app_exec,
-                    &mut count,
-                    &mut time_));
-
-            if ret {
-                let app_exec = FromGlibPtrNotNull::borrow(app_exec);
-                Some((app_exec, count, time_ as i64))
-            }
-            else {
-                None
+            match to_bool(ffi::gtk_recent_info_get_application_info(
+                GTK_RECENT_INFO(self.unwrap_widget()), app_name.borrow_to_glib().0,
+                &mut app_exec, &mut count, &mut time_)) {
+                true => Some((FromGlibPtrNotNull::borrow(app_exec), count, time_ as u64)),
+                _ => None
             }
         }
     }

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -66,16 +66,25 @@ impl RecentInfo {
         }
     }
 
-    pub fn get_added(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_added(GTK_RECENT_INFO(self.unwrap_widget())) as i64 }
+    pub fn get_added(&self) -> Option<u64> {
+        match unsafe { ffi::gtk_recent_info_get_added(GTK_RECENT_INFO(self.unwrap_widget())) } {
+            x if x >= 0 => Some(x as u64),
+            _ => None
+        }
     }
 
-    pub fn get_modified(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_modified(GTK_RECENT_INFO(self.unwrap_widget())) as i64 }
+    pub fn get_modified(&self) -> Option<u64> {
+        match unsafe { ffi::gtk_recent_info_get_modified(GTK_RECENT_INFO(self.unwrap_widget())) } {
+            x if x >= 0 => Some(x as u64),
+            _ => None
+        }
     }
 
-    pub fn get_visited(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_visited(GTK_RECENT_INFO(self.unwrap_widget())) as i64 }
+    pub fn get_visited(&self) -> Option<u64> {
+        match unsafe { ffi::gtk_recent_info_get_visited(GTK_RECENT_INFO(self.unwrap_widget())) } {
+            x if x >= 0 => Some(x as u64),
+            _ => None
+        }
     }
 
     pub fn get_private_hint(&self) -> bool {

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -19,7 +19,7 @@ use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ptr;
 use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, FromGlibPtrContainer, ToGlibPtr};
-use libc::c_char;
+use libc::{c_char, time_t};
 
 struct_Widget!(RecentInfo);
 
@@ -67,15 +67,15 @@ impl RecentInfo {
     }
 
     pub fn get_added(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_added(GTK_RECENT_INFO(self.unwrap_widget())) }
+        unsafe { ffi::gtk_recent_info_get_added(GTK_RECENT_INFO(self.unwrap_widget())) as i64 }
     }
 
     pub fn get_modified(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_modified(GTK_RECENT_INFO(self.unwrap_widget())) }
+        unsafe { ffi::gtk_recent_info_get_modified(GTK_RECENT_INFO(self.unwrap_widget())) as i64 }
     }
 
     pub fn get_visited(&self) -> i64 {
-        unsafe { ffi::gtk_recent_info_get_visited(GTK_RECENT_INFO(self.unwrap_widget())) }
+        unsafe { ffi::gtk_recent_info_get_visited(GTK_RECENT_INFO(self.unwrap_widget())) as i64 }
     }
 
     pub fn get_private_hint(&self) -> bool {
@@ -86,7 +86,7 @@ impl RecentInfo {
         unsafe {
             let mut app_exec = ptr::null();
             let mut count = 0u32;
-            let mut time_ = 0i64;
+            let mut time_: time_t = 0;
 
             let ret = to_bool(
                 ffi::gtk_recent_info_get_application_info(
@@ -98,7 +98,7 @@ impl RecentInfo {
 
             if ret {
                 let app_exec = FromGlibPtrNotNull::borrow(app_exec);
-                Some((app_exec, count, time_))
+                Some((app_exec, count, time_ as i64))
             }
             else {
                 None

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -19,7 +19,7 @@ use gtk::FFIWidget;
 use gtk::cast::GTK_RECENT_INFO;
 use std::ptr;
 use glib::translate::{FromGlibPtr, FromGlibPtrNotNull, FromGlibPtrContainer, ToGlibPtr};
-use libc::{c_char, time_t};
+use libc::c_char;
 
 struct_Widget!(RecentInfo);
 
@@ -85,8 +85,8 @@ impl RecentInfo {
     pub fn get_application_info(&self, app_name: &str) -> Option<(String, u32, i64)> {
         unsafe {
             let mut app_exec = ptr::null();
-            let mut count = 0u32;
-            let mut time_: time_t = 0;
+            let mut count = 0;
+            let mut time_ = 0;
 
             let ret = to_bool(
                 ffi::gtk_recent_info_get_application_info(

--- a/src/gtk/widgets/recent_info.rs
+++ b/src/gtk/widgets/recent_info.rs
@@ -25,7 +25,9 @@ struct_Widget!(RecentInfo);
 
 impl RecentInfo {
     pub fn _ref(&self) -> Option<RecentInfo> {
-        let tmp_pointer = unsafe { ffi::gtk_recent_info_ref(GTK_RECENT_INFO(self.unwrap_widget())) };
+        let tmp_pointer = unsafe {
+            ffi::gtk_recent_info_ref(GTK_RECENT_INFO(self.unwrap_widget()))
+        };
 
         match tmp_pointer.is_null() {
             false => Some(gtk::FFIWidget::wrap_widget(tmp_pointer as *mut ffi::C_GtkWidget)),
@@ -39,29 +41,28 @@ impl RecentInfo {
 
     pub fn get_uri(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_uri(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_get_uri(GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_display_name(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_display_name(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_get_display_name(
+                GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_description(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_description(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_get_description(
+                GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_mime_type(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_mime_type(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_get_mime_type(
+                GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
@@ -87,7 +88,9 @@ impl RecentInfo {
     }
 
     pub fn get_private_hint(&self) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_info_get_private_hint(GTK_RECENT_INFO(self.unwrap_widget()))) }
+        unsafe {
+            to_bool(ffi::gtk_recent_info_get_private_hint(GTK_RECENT_INFO(self.unwrap_widget())))
+        }
     }
 
     pub fn get_application_info(&self, app_name: &str) -> Option<(String, u32, u64)> {
@@ -108,8 +111,7 @@ impl RecentInfo {
     pub fn get_applications(&self) -> Vec<String> {
         unsafe {
             let mut length = 0;
-            let ptr = ffi::gtk_recent_info_get_applications(
-                GTK_RECENT_INFO(self.unwrap_widget()),
+            let ptr = ffi::gtk_recent_info_get_applications(GTK_RECENT_INFO(self.unwrap_widget()),
                 &mut length) as *const *const c_char;
             FromGlibPtrContainer::take_num(ptr, length as usize)
         }
@@ -117,22 +119,22 @@ impl RecentInfo {
 
     pub fn last_application(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_last_application(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_last_application(
+                GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn has_application(&self, app_name: &str) -> bool {
         unsafe {
-            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()), app_name.borrow_to_glib().0))
+            to_bool(ffi::gtk_recent_info_has_application(GTK_RECENT_INFO(self.unwrap_widget()),
+                app_name.borrow_to_glib().0))
         }
     }
 
     pub fn get_groups(&self) -> Vec<String> {
         unsafe {
             let mut length = 0;
-            let ptr = ffi::gtk_recent_info_get_groups(
-                GTK_RECENT_INFO(self.unwrap_widget()),
+            let ptr = ffi::gtk_recent_info_get_groups(GTK_RECENT_INFO(self.unwrap_widget()),
                 &mut length) as *const *const c_char;
             FromGlibPtrContainer::take_num(ptr, length as usize)
         }
@@ -140,23 +142,22 @@ impl RecentInfo {
 
     pub fn has_group(&self, group_name: &str) -> bool {
         unsafe {
-            to_bool(
-                ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.unwrap_widget()),
-                                               group_name.borrow_to_glib().0))
+            to_bool(ffi::gtk_recent_info_has_group(GTK_RECENT_INFO(self.unwrap_widget()),
+                group_name.borrow_to_glib().0))
         }
     }
 
     pub fn get_short_name(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_short_name(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_get_short_name(
+                GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
     pub fn get_uri_display(&self) -> Option<String> {
         unsafe {
-            FromGlibPtr::borrow(
-                ffi::gtk_recent_info_get_uri_display(GTK_RECENT_INFO(self.unwrap_widget())))
+            FromGlibPtr::borrow(ffi::gtk_recent_info_get_uri_display(
+                GTK_RECENT_INFO(self.unwrap_widget())))
         }
     }
 
@@ -173,11 +174,14 @@ impl RecentInfo {
     }
 
     pub fn _match(&self, other: &RecentInfo) -> bool {
-        unsafe { to_bool(ffi::gtk_recent_info_match(GTK_RECENT_INFO(self.unwrap_widget()), GTK_RECENT_INFO(other.unwrap_widget()))) }
+        unsafe {
+            to_bool(ffi::gtk_recent_info_match(GTK_RECENT_INFO(self.unwrap_widget()),
+                GTK_RECENT_INFO(other.unwrap_widget())))
+        }
     }
 }
 
 impl_drop!(RecentInfo);
 impl_TraitWidget!(RecentInfo);
-
 impl_widget_events!(RecentInfo);
+


### PR DESCRIPTION
Fixes issue #1 by applying the following patches:

 - [0001-GtkRecentInfo-use-c_int-to-interface-with-GTK-and-ca.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0001-GtkRecentInfo-use-c_int-to-interface-with-GTK-and-ca.patch)
 - [0002-GtkRecentInfo-use-time_t-instead.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0002-GtkRecentInfo-use-time_t-instead.patch)
 - [0003-GtkRecentInfo-types-can-be-inferred.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0003-GtkRecentInfo-types-can-be-inferred.patch)
 - [0004-GtkRecentInfo-use-Option-u64-instead-of-i64.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0004-GtkRecentInfo-use-Option-u64-instead-of-i64.patch)
 - [0005-GtkRecentInfo-use-match-instead-of-if.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0005-GtkRecentInfo-use-match-instead-of-if.patch)
 - [0006-GtkRecentInfo-code-clean-up.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0006-GtkRecentInfo-code-clean-up.patch)
 - [0007-GtkRecentInfo-added-indents-to-get-the-match-body-to.patch](http://www.synkhronix.com/pub/rust/patches/rgtk/0007-GtkRecentInfo-added-indents-to-get-the-match-body-to.patch)

Uses `time_t` for the arguments of type `time_t` rather than `i64` to make them compatible with both 32-bit and 64-bit architectures. Furthermore, any results of type `time_t` are cast to `i64`.