### PR TITLE
GtkNoteBook: allow more generic arguments, and an example.

### DIFF
--- a/examples/src/note_book.rs
+++ b/examples/src/note_book.rs
@@ -1,0 +1,74 @@
+extern crate gtk;
+
+use gtk::{Connect, IconSize, Orientation, ReliefStyle};
+use gtk::signals::{DeleteEvent, Clicked};
+use gtk::traits::*;
+
+struct NoteBook {
+    notebook: gtk::NoteBook,
+    tabs: Vec<gtk::Box>
+}
+
+impl NoteBook {
+    fn new() -> NoteBook {
+        NoteBook {
+            notebook: gtk::NoteBook::new().unwrap(),
+            tabs: Vec::new()
+        }
+    }
+
+    fn create_tab<'a, Widget: gtk::WidgetTrait>(&mut self, title: &'a str, widget: &Widget) ->
+            Option<u32> {
+        let close_image = gtk::Image::new_from_icon_name("window-close", IconSize::Button).unwrap();
+        let mut button = gtk::Button::new().unwrap();
+        let label = gtk::Label::new(title).unwrap();
+        let mut tab = gtk::Box::new(Orientation::Horizontal, 0).unwrap();
+
+        button.set_relief(ReliefStyle::None);
+        button.set_focus_on_click(false);
+        button.add(&close_image);
+
+        tab.pack_start(&label, false, false, 0);
+        tab.pack_start(&button, false, false, 0);
+        tab.show_all();
+
+        let index = match self.notebook.append_page(widget, Some(&tab)) {
+            Some(index) => index,
+            _ => return None
+        };
+
+        Connect::connect(&button, Clicked::new(&mut || self.notebook.remove_page(index as i32)));
+
+        self.tabs.push(tab);
+
+        Some(index)
+    }
+}
+
+fn main() {
+    gtk::init();
+
+    let mut window = gtk::Window::new(gtk::WindowType::TopLevel).unwrap();
+
+    window.set_title("Notebook");
+    window.set_window_position(gtk::WindowPosition::Center);
+    window.set_default_size(640, 480);
+
+    Connect::connect(&window, DeleteEvent::new(&mut |_| {
+        gtk::main_quit();
+        true
+    }));
+
+    let mut notebook = NoteBook::new();
+
+    for i in 1..4 {
+        let title = format!("sheet {}", i);
+        let label = gtk::Label::new(&title[..]).unwrap();
+        notebook.create_tab(&title[..], &label);
+    }
+
+    window.add(&notebook.notebook);
+    window.show_all();
+    gtk::main();
+}
+

--- a/src/widgets/note_book.rs
+++ b/src/widgets/note_book.rs
@@ -30,79 +30,61 @@ impl NoteBook {
         check_pointer!(tmp_pointer, NoteBook)
     }
 
-    pub fn append_page<T: ::WidgetTrait>(&mut self,
-                                          child: &T,
-                                          tab_label: Option<&::Label>)
-                                          -> i32 {
-        unsafe {
-            ffi::gtk_notebook_append_page(GTK_NOTEBOOK(self.pointer),
-                                          child.unwrap_widget(),
-                                          unwrap_widget!(tab_label))
+    pub fn append_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&mut self, child: &Child,
+            tab_label: Option<&TabLabel>) -> Option<u32> {
+        match unsafe { ffi::gtk_notebook_append_page(GTK_NOTEBOOK(self.pointer),
+                child.unwrap_widget(), unwrap_widget!(tab_label)) } {
+            x if x >= 0 => Some(x as u32),
+            _ => None
         }
     }
 
-    pub fn append_page_menu<T: ::WidgetTrait>(&mut self,
-                                               child: &T,
-                                               tab_label: Option<&::Label>,
-                                               menu_label: Option<&::Label>)
-                                               -> i32 {
-        unsafe {
-            ffi::gtk_notebook_append_page_menu(GTK_NOTEBOOK(self.pointer),
-                                               child.unwrap_widget(),
-                                               unwrap_widget!(tab_label),
-                                               unwrap_widget!(menu_label))
+    pub fn append_page_menu<Child: ::WidgetTrait, TabLabel: ::WidgetTrait,
+            MenuLabel: ::WidgetTrait>(&mut self, child: &Child, tab_label: Option<&TabLabel>,
+            menu_label: Option<&MenuLabel>) -> Option<u32> {
+        match unsafe { ffi::gtk_notebook_append_page_menu(GTK_NOTEBOOK(self.pointer),
+                child.unwrap_widget(), unwrap_widget!(tab_label), unwrap_widget!(menu_label)) } {
+            x if x >= 0 => Some(x as u32),
+            _ => None
         }
     }
 
-    pub fn prepend_page<T: ::WidgetTrait>(&mut self,
-                                           child: &T,
-                                           tab_label: Option<&::Label>)
-                                           -> i32 {
-        unsafe {
-            ffi::gtk_notebook_prepend_page(GTK_NOTEBOOK(self.pointer),
-                                           child.unwrap_widget(),
-                                           unwrap_widget!(tab_label))
+    pub fn prepend_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&mut self, child: &Child,
+            tab_label: Option<&TabLabel>) -> Option<u32> {
+        match unsafe { ffi::gtk_notebook_prepend_page(GTK_NOTEBOOK(self.pointer),
+                child.unwrap_widget(), unwrap_widget!(tab_label)) } {
+            x if x >= 0 => Some(x as u32),
+            _ => None
         }
     }
 
-    pub fn prepend_page_menu<T: ::WidgetTrait>(&mut self,
-                                               child: &T,
-                                               tab_label: Option<&::Label>,
-                                               menu_label: Option<&::Label>)
-                                               -> i32 {
-        unsafe {
-            ffi::gtk_notebook_prepend_page_menu(GTK_NOTEBOOK(self.pointer),
-                                                child.unwrap_widget(),
-                                                unwrap_widget!(tab_label),
-                                                unwrap_widget!(menu_label))
+    pub fn prepend_page_menu<Child: ::WidgetTrait, TabLabel: ::WidgetTrait,
+            MenuLabel: ::WidgetTrait>(&mut self, child: &Child, tab_label: Option<&TabLabel>,
+            menu_label: Option<&MenuLabel>) -> Option<u32> {
+        match unsafe { ffi::gtk_notebook_prepend_page_menu(GTK_NOTEBOOK(self.pointer),
+                child.unwrap_widget(), unwrap_widget!(tab_label), unwrap_widget!(menu_label)) } {
+            x if x >= 0 => Some(x as u32),
+            _ => None
         }
     }
 
-    pub fn insert_page<T: ::WidgetTrait>(&mut self,
-                                           child: &T,
-                                           tab_label: Option<&::Label>,
-                                           position: i32)
-                                           -> i32 {
-        unsafe {
-            ffi::gtk_notebook_insert_page(GTK_NOTEBOOK(self.pointer),
-                                          child.unwrap_widget(),
-                                          unwrap_widget!(tab_label),
-                                          position)
+    pub fn insert_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&mut self, child: &Child,
+            tab_label: Option<&TabLabel>, position: i32) -> Option<u32> {
+        match unsafe { ffi::gtk_notebook_insert_page(GTK_NOTEBOOK(self.pointer),
+                child.unwrap_widget(), unwrap_widget!(tab_label), position) } {
+            x if x >= 0 => Some(x as u32),
+            _ => None
         }
     }
 
-    pub fn insert_page_menu<T: ::WidgetTrait>(&mut self,
-                                               child: &T,
-                                               tab_label: Option<&::Label>,
-                                               menu_label: Option<&::Label>,
-                                               position: i32)
-                                               -> i32 {
-        unsafe {
-            ffi::gtk_notebook_insert_page_menu(GTK_NOTEBOOK(self.pointer),
-                                               child.unwrap_widget(),
-                                               unwrap_widget!(tab_label),
-                                               unwrap_widget!(menu_label),
-                                               position)
+    pub fn insert_page_menu<Child: ::WidgetTrait, TabLabel: ::WidgetTrait,
+            MenuLabel: ::WidgetTrait>(&mut self, child: &Child, tab_label: Option<&TabLabel>,
+            menu_label: Option<&MenuLabel>, position: i32) -> Option<u32> {
+        match unsafe { ffi::gtk_notebook_insert_page_menu(GTK_NOTEBOOK(self.pointer),
+                child.unwrap_widget(), unwrap_widget!(tab_label), unwrap_widget!(menu_label),
+                position) } {
+            x if x >= 0 => Some(x as u32),
+            _ => None
         }
     }
 
@@ -247,7 +229,8 @@ impl NoteBook {
         }
     }
 
-    pub fn get_tab_label<T: ::WidgetTrait>(&self, child: &T) -> Option<::Label> {
+    pub fn get_tab_label<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&self, child: &Child) ->
+            Option<TabLabel> {
         let tmp_pointer = unsafe {
             ffi::gtk_notebook_get_tab_label(GTK_NOTEBOOK(self.pointer),
                                             child.unwrap_widget())
@@ -259,7 +242,8 @@ impl NoteBook {
         }
     }
 
-    pub fn set_tab_label<T: ::WidgetTrait>(&mut self, child: &T, tab_label: Option<&::Label>) {
+    pub fn set_tab_label<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&self, child: &Child,
+            tab_label: Option<&TabLabel>) {
         unsafe {
             ffi::gtk_notebook_set_tab_label(GTK_NOTEBOOK(self.pointer),
                                             child.unwrap_widget(),
@@ -283,7 +267,8 @@ impl NoteBook {
         }
     }
 
-    pub fn get_menu_label<T: ::WidgetTrait>(&self, child: &T) -> Option<::Label> {
+    pub fn get_menu_label<Child: ::WidgetTrait, MenuLabel: ::WidgetTrait>(&self, child: &Child) ->
+            Option<MenuLabel> {
         let tmp_pointer = unsafe {
             ffi::gtk_notebook_get_menu_label(GTK_NOTEBOOK(self.pointer),
                                              child.unwrap_widget())
@@ -295,11 +280,12 @@ impl NoteBook {
         }
     }
 
-    pub fn set_menu_label<T: ::WidgetTrait>(&mut self, child: &T, tab_label: Option<&::Label>) {
+    pub fn set_menu_label<Child: ::WidgetTrait, MenuLabel: ::WidgetTrait>(&self, child: &Child,
+        menu_label: Option<&MenuLabel>) {
         unsafe {
             ffi::gtk_notebook_set_menu_label(GTK_NOTEBOOK(self.pointer),
                                              child.unwrap_widget(),
-                                             unwrap_widget!(tab_label))
+                                             unwrap_widget!(menu_label))
         }
     }
 
@@ -382,3 +368,4 @@ impl_TraitWidget!(NoteBook);
 impl ::ContainerTrait for NoteBook {}
 
 impl_widget_events!(NoteBook);
+


### PR DESCRIPTION
This pull request changes the `GtkNoteBook` methods to accept widgets rather than labels (cfr. issue #26) and to check for failures. In addition, there is also an example of how to use a notebook. However, the use of closures in that example needs some polishing.