### PR TITLE
Make all methods take widgets by & instead of &mut

### DIFF
--- a/src/traits/_box.rs
+++ b/src/traits/_box.rs
@@ -41,7 +41,7 @@ pub trait BoxTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_box_get_homogeneous(GTK_BOX(self.unwrap_widget()))) }
     }
 
-    fn set_homogeneouse(&mut self, homogeneous: bool) -> () {
+    fn set_homogeneouse(&self, homogeneous: bool) -> () {
         unsafe { ffi::gtk_box_set_homogeneous(GTK_BOX(self.unwrap_widget()), to_gboolean(homogeneous)); }
     }
 
@@ -51,7 +51,7 @@ pub trait BoxTrait: ::WidgetTrait {
         }
     }
 
-    fn set_spacing(&mut self, spacing: i32) -> () {
+    fn set_spacing(&self, spacing: i32) -> () {
         unsafe {
             ffi::gtk_box_set_spacing(GTK_BOX(self.unwrap_widget()), spacing as c_int);
         }
@@ -79,7 +79,7 @@ pub trait BoxTrait: ::WidgetTrait {
         (to_bool(c_expand), to_bool(c_fill), c_padding as u32, pack_type)
     }
 
-    fn set_child_packing<'r, T: ::WidgetTrait>(&mut self,
+    fn set_child_packing<'r, T: ::WidgetTrait>(&self,
                                                   child: &'r T,
                                                   expand: bool,
                                                   fill: bool,

--- a/src/traits/button.rs
+++ b/src/traits/button.rs
@@ -53,7 +53,7 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         }
     }
 
-    fn set_relief(&mut self, new_style: ReliefStyle) -> () {
+    fn set_relief(&self, new_style: ReliefStyle) -> () {
         unsafe {
             ffi::gtk_button_set_relief(GTK_BUTTON(self.unwrap_widget()), new_style);
         }
@@ -72,7 +72,7 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         }
     }
 
-    fn set_label(&mut self, label: &str) -> () {
+    fn set_label(&self, label: &str) -> () {
         unsafe {
             ffi::gtk_button_set_label(GTK_BUTTON(self.unwrap_widget()), label.borrow_to_glib().0)
         }
@@ -82,7 +82,7 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         unsafe { to_bool(ffi::gtk_button_get_use_stock(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
-    fn set_use_stock(&mut self, use_stock: bool) -> () {
+    fn set_use_stock(&self, use_stock: bool) -> () {
         unsafe { ffi::gtk_button_set_use_stock(GTK_BUTTON(self.unwrap_widget()), to_gboolean(use_stock)); }
     }
 
@@ -90,11 +90,11 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         unsafe { to_bool(ffi::gtk_button_get_use_underline(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
-    fn set_use_underline(&mut self, use_underline: bool) -> () {
+    fn set_use_underline(&self, use_underline: bool) -> () {
         unsafe { ffi::gtk_button_set_use_underline(GTK_BUTTON(self.unwrap_widget()), to_gboolean(use_underline)); }
     }
 
-    fn set_focus_on_click(&mut self, focus_on_click: bool) -> () {
+    fn set_focus_on_click(&self, focus_on_click: bool) -> () {
         unsafe { ffi::gtk_button_set_focus_on_click(GTK_BUTTON(self.unwrap_widget()), to_gboolean(focus_on_click)); }
     }
 
@@ -102,7 +102,7 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         unsafe { to_bool(ffi::gtk_button_get_focus_on_click(GTK_BUTTON(self.unwrap_widget()))) }
     }
 
-    fn set_alignment(&mut self, x_align: f32, y_align: f32) -> () {
+    fn set_alignment(&self, x_align: f32, y_align: f32) -> () {
         unsafe {
             ffi::gtk_button_set_alignment(GTK_BUTTON(self.unwrap_widget()), x_align as c_float, y_align as c_float)
         }
@@ -117,13 +117,13 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         (x_align as f32, y_align as f32)
     }
 
-    fn set_image<T: ::WidgetTrait>(&mut self, image: &T) -> () {
+    fn set_image<T: ::WidgetTrait>(&self, image: &T) -> () {
         unsafe {
             ffi::gtk_button_set_image(GTK_BUTTON(self.unwrap_widget()), image.unwrap_widget());
         }
     }
 
-    fn set_image_position(&mut self, position: PositionType) -> () {
+    fn set_image_position(&self, position: PositionType) -> () {
         unsafe {
             ffi::gtk_button_set_image_position(GTK_BUTTON(self.unwrap_widget()), position);
         }
@@ -136,7 +136,7 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
     }
 
     #[cfg(feature = "gtk_3_6")]
-    fn set_always_show_image(&mut self, always_show: bool) -> () {
+    fn set_always_show_image(&self, always_show: bool) -> () {
         unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.unwrap_widget()), to_gboolean(always_show)); }
     }
 

--- a/src/traits/check_menu_item.rs
+++ b/src/traits/check_menu_item.rs
@@ -25,7 +25,7 @@ pub trait CheckMenuItemTrait: ::WidgetTrait +
                               ::BinTrait +
                               ::MenuItemTrait {
 
-    fn set_active(&mut self, is_active: bool) {
+    fn set_active(&self, is_active: bool) {
         unsafe {
             ffi::gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(self.unwrap_widget()),
                                                 to_gboolean(is_active))
@@ -38,13 +38,13 @@ pub trait CheckMenuItemTrait: ::WidgetTrait +
         }
     }
 
-    fn toggled(&mut self) {
+    fn toggled(&self) {
         unsafe {
             ffi::gtk_check_menu_item_toggled(GTK_CHECK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
-    fn set_inconsistent(&mut self, setting: bool) {
+    fn set_inconsistent(&self, setting: bool) {
         unsafe {
             ffi::gtk_check_menu_item_set_inconsistent(GTK_CHECK_MENU_ITEM(self.unwrap_widget()),
                                                       to_gboolean(setting))
@@ -57,7 +57,7 @@ pub trait CheckMenuItemTrait: ::WidgetTrait +
         }
     }
 
-    fn set_draw_as_radio(&mut self, setting: bool) {
+    fn set_draw_as_radio(&self, setting: bool) {
         unsafe {
             ffi::gtk_check_menu_item_set_draw_as_radio(GTK_CHECK_MENU_ITEM(self.unwrap_widget()),
                                                        to_gboolean(setting))

--- a/src/traits/container.rs
+++ b/src/traits/container.rs
@@ -38,7 +38,7 @@ pub trait ContainerTrait: ::WidgetTrait {
         }
     }
 
-    fn set_resize_mode(&mut self, resize_mode: ResizeMode) -> () {
+    fn set_resize_mode(&self, resize_mode: ResizeMode) -> () {
         unsafe {
             ffi::gtk_container_set_resize_mode(GTK_CONTAINER(self.unwrap_widget()), resize_mode);
         }

--- a/src/traits/editable.rs
+++ b/src/traits/editable.rs
@@ -20,7 +20,7 @@ use glib::translate::{FromGlibPtr};
 use glib::{to_bool, to_gboolean};
 
 pub trait EditableTrait: ::WidgetTrait {
-    fn select_region(&mut self, start_pos: i32, end_pos: i32) {
+    fn select_region(&self, start_pos: i32, end_pos: i32) {
         unsafe {
             ffi::gtk_editable_select_region(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos)
         }
@@ -40,7 +40,7 @@ pub trait EditableTrait: ::WidgetTrait {
         }
     }
 
-    fn insert_text(&mut self, new_text: &str, position: &mut i32) {
+    fn insert_text(&self, new_text: &str, position: &mut i32) {
         unsafe {
             // Don't need a null-terminated string here
             ffi::gtk_editable_insert_text(GTK_EDITABLE(self.unwrap_widget()),
@@ -50,7 +50,7 @@ pub trait EditableTrait: ::WidgetTrait {
         }
     }
 
-    fn delete_text(&mut self, start_pos: i32, end_pos: i32) {
+    fn delete_text(&self, start_pos: i32, end_pos: i32) {
         unsafe {
             ffi::gtk_editable_delete_text(GTK_EDITABLE(self.unwrap_widget()), start_pos, end_pos)
         }
@@ -63,31 +63,31 @@ pub trait EditableTrait: ::WidgetTrait {
         }
     }
 
-    fn cut_clipboard(&mut self) {
+    fn cut_clipboard(&self) {
         unsafe {
             ffi::gtk_editable_cut_clipboard(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
-    fn copy_clipboard(&mut self) {
+    fn copy_clipboard(&self) {
         unsafe {
             ffi::gtk_editable_copy_clipboard(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
-    fn paste_clipboard(&mut self) {
+    fn paste_clipboard(&self) {
         unsafe {
             ffi::gtk_editable_paste_clipboard(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
-    fn delete_selection(&mut self) {
+    fn delete_selection(&self) {
         unsafe {
             ffi::gtk_editable_delete_selection(GTK_EDITABLE(self.unwrap_widget()))
         }
     }
 
-    fn set_position(&mut self, position: i32) {
+    fn set_position(&self, position: i32) {
         unsafe {
             ffi::gtk_editable_set_editable(GTK_EDITABLE(self.unwrap_widget()), position)
         }
@@ -99,7 +99,7 @@ pub trait EditableTrait: ::WidgetTrait {
         }
     }
 
-    fn set_editable(&mut self, editable: bool) {
+    fn set_editable(&self, editable: bool) {
         unsafe {
             ffi::gtk_editable_set_editable(GTK_EDITABLE(self.unwrap_widget()), to_gboolean(editable))
         }

--- a/src/traits/entry.rs
+++ b/src/traits/entry.rs
@@ -28,13 +28,13 @@ pub trait EntryTrait: ::WidgetTrait {
         ::EntryBuffer::wrap_pointer(tmp_pointer)
     }
 
-    fn set_buffer(&mut self, buffer: &::EntryBuffer) -> () {
+    fn set_buffer(&self, buffer: &::EntryBuffer) -> () {
         unsafe {
             ffi::gtk_entry_set_buffer(GTK_ENTRY(self.unwrap_widget()), buffer.unwrap_pointer())
         }
     }
 
-    fn set_text(&mut self, text: &str) {
+    fn set_text(&self, text: &str) {
         unsafe {
             ffi::gtk_entry_set_text(GTK_ENTRY(self.unwrap_widget()), text.borrow_to_glib().0)
         }
@@ -53,23 +53,23 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_visibility(&mut self, visible: bool) -> () {
+    fn set_visibility(&self, visible: bool) -> () {
         unsafe { ffi::gtk_entry_set_visibility(GTK_ENTRY(self.unwrap_widget()), to_gboolean(visible)); }
     }
 
-    fn set_invisible_char(&mut self, ch: i32) -> () {
+    fn set_invisible_char(&self, ch: i32) -> () {
         unsafe {
             ffi::gtk_entry_set_invisible_char(GTK_ENTRY(self.unwrap_widget()), ch as c_int);
         }
     }
 
-    fn unset_invisible_char(&mut self) -> () {
+    fn unset_invisible_char(&self) -> () {
         unsafe {
             ffi::gtk_entry_unset_invisible_char(GTK_ENTRY(self.unwrap_widget()));
         }
     }
 
-    fn set_max_length(&mut self, max_length: i32) -> () {
+    fn set_max_length(&self, max_length: i32) -> () {
         unsafe {
             ffi::gtk_entry_set_max_length(GTK_ENTRY(self.unwrap_widget()), max_length as c_int);
         }
@@ -89,15 +89,15 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_activates_default(&mut self, setting: bool) {
+    fn set_activates_default(&self, setting: bool) {
         unsafe { ffi::gtk_entry_set_activates_default(GTK_ENTRY(self.unwrap_widget()), to_gboolean(setting)); }
     }
 
-    fn set_has_frame(&mut self, setting: bool) {
+    fn set_has_frame(&self, setting: bool) {
         unsafe { ffi::gtk_entry_set_has_frame(GTK_ENTRY(self.unwrap_widget()), to_gboolean(setting)); }
     }
 
-    fn set_width_chars(&mut self, n_chars: i32) -> () {
+    fn set_width_chars(&self, n_chars: i32) -> () {
         unsafe {
             ffi::gtk_entry_set_width_chars(GTK_ENTRY(self.unwrap_widget()), n_chars as c_int);
         }
@@ -109,7 +109,7 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_alignment(&mut self, x_align: f32) -> () {
+    fn set_alignment(&self, x_align: f32) -> () {
         unsafe {
             ffi::gtk_entry_set_alignment(GTK_ENTRY(self.unwrap_widget()), x_align as c_float);
         }
@@ -121,7 +121,7 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_placeholder(&mut self, text: &str) -> () {
+    fn set_placeholder(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_entry_set_placeholder_text(GTK_ENTRY(self.unwrap_widget()), text.borrow_to_glib().0)
         }
@@ -138,7 +138,7 @@ pub trait EntryTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_entry_get_overwrite_mode(GTK_ENTRY(self.unwrap_widget()))) }
     }
 
-    fn set_overwrite_mode(&mut self, overwrite: bool) {
+    fn set_overwrite_mode(&self, overwrite: bool) {
         unsafe { ffi::gtk_entry_set_overwrite_mode(GTK_ENTRY(self.unwrap_widget()), to_gboolean(overwrite)); }
     }
 
@@ -174,7 +174,7 @@ pub trait EntryTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_entry_get_visibility(GTK_ENTRY(self.unwrap_widget()))) }
     }
 
-    fn set_cursor_hadjustment(&mut self, adjustment: &::Adjustment) -> () {
+    fn set_cursor_hadjustment(&self, adjustment: &::Adjustment) -> () {
         unsafe {
             ffi::gtk_entry_set_cursor_hadjustment(GTK_ENTRY(self.unwrap_widget()), adjustment.unwrap_pointer())
         }
@@ -186,49 +186,49 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_progress_fraction(&mut self, fraction: f64) -> () {
+    fn set_progress_fraction(&self, fraction: f64) -> () {
         unsafe {
             ffi::gtk_entry_set_progress_fraction(GTK_ENTRY(self.unwrap_widget()), fraction as c_double);
         }
     }
 
-    fn get_progress_fraction(&mut self) -> f64 {
+    fn get_progress_fraction(&self) -> f64 {
         unsafe {
             ffi::gtk_entry_get_progress_fraction(GTK_ENTRY(self.unwrap_widget())) as f64
         }
     }
 
-    fn set_progress_pulse_step(&mut self, pulse_step: f64) -> () {
+    fn set_progress_pulse_step(&self, pulse_step: f64) -> () {
         unsafe {
             ffi::gtk_entry_set_progress_pulse_step(GTK_ENTRY(self.unwrap_widget()), pulse_step as c_double);
         }
     }
 
-    fn get_progress_pulse_step(&mut self) -> f64 {
+    fn get_progress_pulse_step(&self) -> f64 {
         unsafe {
             ffi::gtk_entry_get_progress_pulse_step(GTK_ENTRY(self.unwrap_widget())) as f64
         }
     }
 
-    fn progress_pulse(&mut self) -> () {
+    fn progress_pulse(&self) -> () {
         unsafe {
             ffi::gtk_entry_progress_pulse(GTK_ENTRY(self.unwrap_widget()));
         }
     }
 
-    fn reset_im_context(&mut self) -> () {
+    fn reset_im_context(&self) -> () {
         unsafe {
             ffi::gtk_entry_reset_im_context(GTK_ENTRY(self.unwrap_widget()));
         }
     }
 
-    fn set_icon_from_stock(&mut self, icon_pos: EntryIconPosition, stock_id: &str) -> () {
+    fn set_icon_from_stock(&self, icon_pos: EntryIconPosition, stock_id: &str) -> () {
         unsafe {
             ffi::gtk_entry_set_icon_from_stock(GTK_ENTRY(self.unwrap_widget()), icon_pos, stock_id.borrow_to_glib().0);
         }
     }
 
-    fn set_icon_from_icon_name(&mut self, icon_pos: EntryIconPosition, icon_name: &str) -> () {
+    fn set_icon_from_icon_name(&self, icon_pos: EntryIconPosition, icon_name: &str) -> () {
         unsafe {
             ffi::gtk_entry_set_icon_from_icon_name(GTK_ENTRY(self.unwrap_widget()), icon_pos, icon_name.borrow_to_glib().0)
         }
@@ -258,7 +258,7 @@ pub trait EntryTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_entry_get_icon_activatable(GTK_ENTRY(self.unwrap_widget()), icon_pos)) }
     }
 
-    fn set_icon_activatable(&mut self, icon_pos: EntryIconPosition, activatable: bool) {
+    fn set_icon_activatable(&self, icon_pos: EntryIconPosition, activatable: bool) {
         unsafe { ffi::gtk_entry_set_icon_activatable(GTK_ENTRY(self.unwrap_widget()), icon_pos, to_gboolean(activatable)); }
     }
 
@@ -266,7 +266,7 @@ pub trait EntryTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_entry_get_icon_sensitive(GTK_ENTRY(self.unwrap_widget()), icon_pos)) }
     }
 
-    fn set_icon_sensitive(&mut self, icon_pos: EntryIconPosition, sensitive: bool) {
+    fn set_icon_sensitive(&self, icon_pos: EntryIconPosition, sensitive: bool) {
         unsafe { ffi::gtk_entry_set_icon_sensitive(GTK_ENTRY(self.unwrap_widget()), icon_pos, to_gboolean(sensitive)); }
     }
 
@@ -276,7 +276,7 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_icon_tooltip_text(&mut self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
+    fn set_icon_tooltip_text(&self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
         unsafe {
             ffi::gtk_entry_set_icon_tooltip_text(GTK_ENTRY(self.unwrap_widget()), icon_pos, tooltip.borrow_to_glib().0)
         }
@@ -290,7 +290,7 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_icon_tooltip_markup(&mut self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
+    fn set_icon_tooltip_markup(&self, icon_pos: EntryIconPosition, tooltip: &str) -> () {
         unsafe {
             ffi::gtk_entry_set_icon_tooltip_markup(GTK_ENTRY(self.unwrap_widget()), icon_pos, tooltip.borrow_to_glib().0)
         }
@@ -310,7 +310,7 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_input_purpose(&mut self, purpose: InputPurpose) -> () {
+    fn set_input_purpose(&self, purpose: InputPurpose) -> () {
         unsafe {
             ffi::gtk_entry_set_input_purpose(GTK_ENTRY(self.unwrap_widget()), purpose)
         }
@@ -322,7 +322,7 @@ pub trait EntryTrait: ::WidgetTrait {
         }
     }
 
-    fn set_input_hints(&mut self, hints: InputHints) -> () {
+    fn set_input_hints(&self, hints: InputHints) -> () {
         unsafe {
             ffi::gtk_entry_set_input_hints(GTK_ENTRY(self.unwrap_widget()), hints)
         }

--- a/src/traits/frame.rs
+++ b/src/traits/frame.rs
@@ -21,20 +21,20 @@ use cast::GTK_FRAME;
 use ffi;
 
 pub trait FrameTrait: ::WidgetTrait + ::ContainerTrait {
-    fn set_label(&mut self, label: Option<&str>) -> () {
+    fn set_label(&self, label: Option<&str>) -> () {
         unsafe {
             ffi::gtk_frame_set_label(GTK_FRAME(self.unwrap_widget()),
                                      label.borrow_to_glib().0);
         }
     }
 
-    fn set_label_widget<T: ::WidgetTrait>(&mut self, label_widget: &T) -> () {
+    fn set_label_widget<T: ::WidgetTrait>(&self, label_widget: &T) -> () {
         unsafe {
             ffi::gtk_frame_set_label_widget(GTK_FRAME(self.unwrap_widget()), label_widget.unwrap_widget());
         }
     }
 
-    fn set_label_align(&mut self, x_align: f32, y_align: f32) -> () {
+    fn set_label_align(&self, x_align: f32, y_align: f32) -> () {
         unsafe {
             ffi::gtk_frame_set_label_align(GTK_FRAME(self.unwrap_widget()), x_align as c_float, y_align as c_float);
         }
@@ -49,7 +49,7 @@ pub trait FrameTrait: ::WidgetTrait + ::ContainerTrait {
         (x_align as f32, y_align as f32)
     }
 
-    fn set_shadow_type(&mut self, st_type: ShadowType) -> () {
+    fn set_shadow_type(&self, st_type: ShadowType) -> () {
         unsafe {
             ffi::gtk_frame_set_shadow_type(GTK_FRAME(self.unwrap_widget()), st_type);
         }

--- a/src/traits/label.rs
+++ b/src/traits/label.rs
@@ -22,61 +22,61 @@ use Justification;
 use cast::GTK_LABEL;
 
 pub trait LabelTrait: ::WidgetTrait {
-    fn set_label(&mut self, text: &str) -> () {
+    fn set_label(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_label_set_label(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
-    fn set_text(&mut self, text: &str) -> () {
+    fn set_text(&self, text: &str) -> () {
         unsafe {
 	    ffi::gtk_label_set_text(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
-    fn set_justify(&mut self, jtype: Justification) -> () {
+    fn set_justify(&self, jtype: Justification) -> () {
         unsafe {
             ffi::gtk_label_set_justify(GTK_LABEL(self.unwrap_widget()), jtype);
         }
     }
 
-    fn set_markup(&mut self, text: &str) -> () {
+    fn set_markup(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_label_set_markup(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
-    fn set_markup_with_mnemonic(&mut self, text: &str) -> () {
+    fn set_markup_with_mnemonic(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_label_set_markup_with_mnemonic(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
-    fn set_pattern(&mut self, text: &str) -> () {
+    fn set_pattern(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_label_set_pattern(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0)
         }
     }
 
-    fn set_text_with_mnemonic(&mut self, text: &str) -> () {
+    fn set_text_with_mnemonic(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_label_set_text_with_mnemonic(GTK_LABEL(self.unwrap_widget()), text.borrow_to_glib().0);
         }
     }
 
-    fn set_width_chars(&mut self, n_chars: i32) -> () {
+    fn set_width_chars(&self, n_chars: i32) -> () {
         unsafe {
             ffi::gtk_label_set_width_chars(GTK_LABEL(self.unwrap_widget()), n_chars as c_int);
         }
     }
 
-    fn set_max_width_chars(&mut self, n_chars: i32) -> () {
+    fn set_max_width_chars(&self, n_chars: i32) -> () {
         unsafe {
             ffi::gtk_label_set_max_width_chars(GTK_LABEL(self.unwrap_widget()), n_chars as c_int);
         }
     }
 
-    fn set_line_wrap(&mut self, wrap: bool) -> () {
+    fn set_line_wrap(&self, wrap: bool) -> () {
         unsafe { ffi::gtk_label_set_line_wrap(GTK_LABEL(self.unwrap_widget()), to_gboolean(wrap)); }
     }
 
@@ -85,7 +85,7 @@ pub trait LabelTrait: ::WidgetTrait {
     }
 
     #[cfg(feature = "gtk_3_10")]
-    fn set_lines(&mut self, lines: i32) -> () {
+    fn set_lines(&self, lines: i32) -> () {
         unsafe {
             ffi::gtk_label_set_lines(GTK_LABEL(self.unwrap_widget()), lines as c_int);
         }
@@ -113,7 +113,7 @@ pub trait LabelTrait: ::WidgetTrait {
         }
     }
 
-    fn set_selectable(&mut self, selectable: bool) -> () {
+    fn set_selectable(&self, selectable: bool) -> () {
         unsafe { ffi::gtk_label_set_selectable(GTK_LABEL(self.unwrap_widget()), to_gboolean(selectable)); }
     }
 
@@ -121,7 +121,7 @@ pub trait LabelTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_label_get_selectable(GTK_LABEL(self.unwrap_widget()))) }
     }
 
-    fn set_use_markup(&mut self, use_markup: bool) -> () {
+    fn set_use_markup(&self, use_markup: bool) -> () {
         unsafe { ffi::gtk_label_set_use_markup(GTK_LABEL(self.unwrap_widget()), to_gboolean(use_markup)); }
     }
 
@@ -129,7 +129,7 @@ pub trait LabelTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_label_get_use_markup(GTK_LABEL(self.unwrap_widget()))) }
     }
 
-    fn set_use_underline(&mut self, use_underline: bool) -> () {
+    fn set_use_underline(&self, use_underline: bool) -> () {
         unsafe { ffi::gtk_label_set_use_underline(GTK_LABEL(self.unwrap_widget()), to_gboolean(use_underline)); }
     }
 
@@ -137,7 +137,7 @@ pub trait LabelTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_label_get_use_underline(GTK_LABEL(self.unwrap_widget()))) }
     }
 
-    fn set_single_line_mode(&mut self, single_line_mode: bool) -> () {
+    fn set_single_line_mode(&self, single_line_mode: bool) -> () {
         unsafe { ffi::gtk_label_set_single_line_mode(GTK_LABEL(self.unwrap_widget()), to_gboolean(single_line_mode)); }
     }
 
@@ -145,7 +145,7 @@ pub trait LabelTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_label_get_single_line_mode(GTK_LABEL(self.unwrap_widget()))) }
     }
 
-    fn set_track_visited_links(&mut self, track_visited_links: bool) -> () {
+    fn set_track_visited_links(&self, track_visited_links: bool) -> () {
         unsafe { ffi::gtk_label_set_track_visited_links(GTK_LABEL(self.unwrap_widget()), to_gboolean(track_visited_links)); }
     }
 
@@ -174,7 +174,7 @@ pub trait LabelTrait: ::WidgetTrait {
         }
     }
 
-    fn select_region(&mut self, start_offset: i32, end_offset: i32) -> () {
+    fn select_region(&self, start_offset: i32, end_offset: i32) -> () {
         unsafe {
             ffi::gtk_label_select_region(GTK_LABEL(self.unwrap_widget()), start_offset as c_int, end_offset as c_int);
         }
@@ -207,7 +207,7 @@ pub trait LabelTrait: ::WidgetTrait {
         (x, y)
     }
 
-    fn set_angle(&mut self, angle: f64) -> () {
+    fn set_angle(&self, angle: f64) -> () {
         unsafe {
             ffi::gtk_label_set_angle(GTK_LABEL(self.unwrap_widget()), angle as c_double);
         }

--- a/src/traits/menu_item.rs
+++ b/src/traits/menu_item.rs
@@ -22,7 +22,7 @@ use glib::{to_bool, to_gboolean};
 
 /// The widget used for item in menus
 pub trait MenuItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
-    fn set_submenu<T: ::WidgetTrait>(&mut self, widget: &mut T) {
+    fn set_submenu<T: ::WidgetTrait>(&self, widget: &T) {
         unsafe {
             ffi::gtk_menu_item_set_submenu(GTK_MENU_ITEM(self.unwrap_widget()),
                                            widget.unwrap_widget())
@@ -35,25 +35,25 @@ pub trait MenuItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         }
     }
 
-    fn select(&mut self) {
+    fn select(&self) {
         unsafe {
             ffi::gtk_menu_item_select(GTK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
-    fn deselect(&mut self) {
+    fn deselect(&self) {
         unsafe {
             ffi::gtk_menu_item_deselect(GTK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
-    fn activate(&mut self) {
+    fn activate(&self) {
         unsafe {
             ffi::gtk_menu_item_activate(GTK_MENU_ITEM(self.unwrap_widget()))
         }
     }
 
-    fn set_accel_path(&mut self, accel_path: &str) {
+    fn set_accel_path(&self, accel_path: &str) {
         unsafe {
             ffi::gtk_menu_item_set_accel_path(GTK_MENU_ITEM(self.unwrap_widget()), accel_path.borrow_to_glib().0)
         }
@@ -66,7 +66,7 @@ pub trait MenuItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         }
     }
 
-    fn set_label(&mut self, label: &str) {
+    fn set_label(&self, label: &str) {
         unsafe {
             ffi::gtk_menu_item_set_label(GTK_MENU_ITEM(self.unwrap_widget()),
                                          label.borrow_to_glib().0)
@@ -80,7 +80,7 @@ pub trait MenuItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         }
     }
 
-    fn set_use_underline(&mut self, setting: bool) {
+    fn set_use_underline(&self, setting: bool) {
         unsafe {
             ffi::gtk_menu_item_set_use_underline(GTK_MENU_ITEM(self.unwrap_widget()),
                                                  to_gboolean(setting))
@@ -93,7 +93,7 @@ pub trait MenuItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         }
     }
 
-    fn set_reserve_indicator(&mut self, setting: bool) {
+    fn set_reserve_indicator(&self, setting: bool) {
         unsafe {
             ffi::gtk_menu_item_set_reserve_indicator(GTK_MENU_ITEM(self.unwrap_widget()),
                                                      to_gboolean(setting))

--- a/src/traits/menu_shell.rs
+++ b/src/traits/menu_shell.rs
@@ -21,19 +21,19 @@ use glib::{to_bool, to_gboolean};
 
 /// A base class for menu objects
 pub trait MenuShellTrait: ::WidgetTrait + ::ContainerTrait {
-    fn append<T: ::WidgetTrait>(&mut self, widget: &T) {
+    fn append<T: ::WidgetTrait>(&self, widget: &T) {
         unsafe {
             ffi::gtk_menu_shell_append(GTK_MENU_SHELL(self.unwrap_widget()), widget.unwrap_widget())
         }
     }
 
-    fn prepend<T: ::WidgetTrait>(&mut self, widget: &T) {
+    fn prepend<T: ::WidgetTrait>(&self, widget: &T) {
         unsafe {
             ffi::gtk_menu_shell_prepend(GTK_MENU_SHELL(self.unwrap_widget()), widget.unwrap_widget())
         }
     }
 
-    fn insert<T: ::WidgetTrait>(&mut self, widget: &T, position: i32) {
+    fn insert<T: ::WidgetTrait>(&self, widget: &T, position: i32) {
         unsafe {
             ffi::gtk_menu_shell_insert(GTK_MENU_SHELL(self.unwrap_widget()),
                                        widget.unwrap_widget(),
@@ -41,26 +41,26 @@ pub trait MenuShellTrait: ::WidgetTrait + ::ContainerTrait {
         }
     }
 
-    fn deactivate(&mut self) {
+    fn deactivate(&self) {
         unsafe {
             ffi::gtk_menu_shell_deactivate(GTK_MENU_SHELL(self.unwrap_widget()))
         }
     }
 
-    fn select_item<T: ::MenuItemTrait>(&mut self, menu_item: &T) {
+    fn select_item<T: ::MenuItemTrait>(&self, menu_item: &T) {
         unsafe {
             ffi::gtk_menu_shell_select_item(GTK_MENU_SHELL(self.unwrap_widget()),
                                             menu_item.unwrap_widget())
         }
     }
 
-    fn deselect(&mut self) {
+    fn deselect(&self) {
         unsafe {
             ffi::gtk_menu_shell_deselect(GTK_MENU_SHELL(self.unwrap_widget()))
         }
     }
 
-    fn activate_item<T: ::MenuItemTrait>(&mut self, menu_item: &T, force_deactivate: bool) {
+    fn activate_item<T: ::MenuItemTrait>(&self, menu_item: &T, force_deactivate: bool) {
         unsafe {
             ffi::gtk_menu_shell_activate_item(GTK_MENU_SHELL(self.unwrap_widget()),
                                               menu_item.unwrap_widget(),
@@ -68,14 +68,14 @@ pub trait MenuShellTrait: ::WidgetTrait + ::ContainerTrait {
         }
     }
 
-    fn select_first(&mut self, search_sensitive: bool) {
+    fn select_first(&self, search_sensitive: bool) {
         unsafe {
             ffi::gtk_menu_shell_select_first(GTK_MENU_SHELL(self.unwrap_widget()),
                                              to_gboolean(search_sensitive))
         }
     }
 
-    fn cancel(&mut self) {
+    fn cancel(&self) {
         unsafe {
             ffi::gtk_menu_shell_cancel(GTK_MENU_SHELL(self.unwrap_widget()))
         }
@@ -87,7 +87,7 @@ pub trait MenuShellTrait: ::WidgetTrait + ::ContainerTrait {
         }
     }
 
-    fn set_take_focus(&mut self, take_focus: bool) {
+    fn set_take_focus(&self, take_focus: bool) {
         unsafe {
             ffi::gtk_menu_shell_set_take_focus(GTK_MENU_SHELL(self.unwrap_widget()),
                                                to_gboolean(take_focus))

--- a/src/traits/misc.rs
+++ b/src/traits/misc.rs
@@ -18,13 +18,13 @@ use cast::GTK_MISC;
 use ffi;
 
 pub trait MiscTrait: ::WidgetTrait {
-    fn set_alignment(&mut self, x_align: f32, y_align: f32) -> () {
+    fn set_alignment(&self, x_align: f32, y_align: f32) -> () {
         unsafe {
             ffi::gtk_misc_set_alignment(GTK_MISC(self.unwrap_widget()), x_align as c_float, y_align as c_float);
         }
     }
 
-    fn set_padding(&mut self, x_pad: i32, y_pad: i32) -> () {
+    fn set_padding(&self, x_pad: i32, y_pad: i32) -> () {
         unsafe {
             ffi::gtk_misc_set_padding(GTK_MISC(self.unwrap_widget()), x_pad as c_int, y_pad as c_int);
         }

--- a/src/traits/orientable.rs
+++ b/src/traits/orientable.rs
@@ -24,7 +24,7 @@ pub trait OrientableTrait: ::WidgetTrait {
         }
     }
 
-    fn set_orientation(&mut self, orientation: Orientation) -> () {
+    fn set_orientation(&self, orientation: Orientation) -> () {
         unsafe {
             ffi::gtk_orientable_set_orientation(GTK_ORIENTABLE(self.unwrap_widget()), orientation)
         }

--- a/src/traits/range.rs
+++ b/src/traits/range.rs
@@ -17,7 +17,7 @@ use cast::GTK_RANGE;
 use ffi;
 
 pub trait RangeTrait: ::WidgetTrait {
-    fn set_adjustment(&mut self, adjustment: &::Adjustment) -> () {
+    fn set_adjustment(&self, adjustment: &::Adjustment) -> () {
         unsafe {
             ffi::gtk_range_set_adjustment(GTK_RANGE(self.unwrap_widget()), adjustment.unwrap_pointer());
         }

--- a/src/traits/scale_button.rs
+++ b/src/traits/scale_button.rs
@@ -19,13 +19,13 @@ use cast::GTK_SCALEBUTTON;
 use ffi;
 
 pub trait ScaleButtonTrait: ::WidgetTrait + ::ContainerTrait + ::ButtonTrait {
-    fn set_adjustment(&mut self, adjustment: &::Adjustment) -> () {
+    fn set_adjustment(&self, adjustment: &::Adjustment) -> () {
         unsafe {
             ffi::gtk_scale_button_set_adjustment(GTK_SCALEBUTTON(self.unwrap_widget()), adjustment.unwrap_pointer());
         }
     }
 
-    fn set_value(&mut self, value: f64) -> () {
+    fn set_value(&self, value: f64) -> () {
         unsafe {
             ffi::gtk_scale_button_set_value(GTK_SCALEBUTTON(self.unwrap_widget()), value as c_double);
         }

--- a/src/traits/scrollable.rs
+++ b/src/traits/scrollable.rs
@@ -26,7 +26,7 @@ pub trait ScrollableTrait: ::WidgetTrait {
         }
     }
 
-    fn set_hadjustment(&mut self, hadjustment: ::Adjustment) {
+    fn set_hadjustment(&self, hadjustment: ::Adjustment) {
         unsafe {
             ffi::gtk_scrollable_set_hadjustment(GTK_SCROLLABLE(self.unwrap_widget()),
                                                 hadjustment.unwrap_pointer())
@@ -39,7 +39,7 @@ pub trait ScrollableTrait: ::WidgetTrait {
         }
     }
 
-    fn set_vadjustment(&mut self, vadjustment: ::Adjustment) {
+    fn set_vadjustment(&self, vadjustment: ::Adjustment) {
         unsafe {
             ffi::gtk_scrollable_set_vadjustment(GTK_SCROLLABLE(self.unwrap_widget()),
                                                 vadjustment.unwrap_pointer())
@@ -52,7 +52,7 @@ pub trait ScrollableTrait: ::WidgetTrait {
         }
     }
 
-    fn set_hscroll_policy(&mut self, policy: ::ScrollablePolicy) {
+    fn set_hscroll_policy(&self, policy: ::ScrollablePolicy) {
         unsafe {
             ffi::gtk_scrollable_set_hscroll_policy(GTK_SCROLLABLE(self.unwrap_widget()),
                                                    policy)
@@ -65,7 +65,7 @@ pub trait ScrollableTrait: ::WidgetTrait {
         }
     }
 
-    fn set_vscroll_policy(&mut self, policy: ::ScrollablePolicy) {
+    fn set_vscroll_policy(&self, policy: ::ScrollablePolicy) {
         unsafe {
             ffi::gtk_scrollable_set_vscroll_policy(GTK_SCROLLABLE(self.unwrap_widget()),
                                                    policy)

--- a/src/traits/toggle_button.rs
+++ b/src/traits/toggle_button.rs
@@ -18,7 +18,7 @@ use ffi;
 use glib::{to_bool, to_gboolean};
 
 pub trait ToggleButtonTrait: ::WidgetTrait + ::ContainerTrait + ::ButtonTrait {
-    fn set_mode(&mut self, draw_indicate: bool) {
+    fn set_mode(&self, draw_indicate: bool) {
         unsafe { ffi::gtk_toggle_button_set_mode(GTK_TOGGLEBUTTON(self.unwrap_widget()), to_gboolean(draw_indicate)); }
     }
 
@@ -26,13 +26,13 @@ pub trait ToggleButtonTrait: ::WidgetTrait + ::ContainerTrait + ::ButtonTrait {
         unsafe { to_bool(ffi::gtk_toggle_button_get_mode(GTK_TOGGLEBUTTON(self.unwrap_widget()))) }
     }
 
-    fn toggled(&mut self) -> () {
+    fn toggled(&self) -> () {
         unsafe {
             ffi::gtk_toggle_button_toggled(GTK_TOGGLEBUTTON(self.unwrap_widget()))
         }
     }
 
-    fn set_active(&mut self, is_active: bool) {
+    fn set_active(&self, is_active: bool) {
         unsafe { ffi::gtk_toggle_button_set_active(GTK_TOGGLEBUTTON(self.unwrap_widget()), to_gboolean(is_active)); }
     }
 
@@ -40,7 +40,7 @@ pub trait ToggleButtonTrait: ::WidgetTrait + ::ContainerTrait + ::ButtonTrait {
         unsafe { to_bool(ffi::gtk_toggle_button_get_active(GTK_TOGGLEBUTTON(self.unwrap_widget()))) }
     }
 
-    fn set_inconsistent(&mut self, setting: bool) {
+    fn set_inconsistent(&self, setting: bool) {
         unsafe { ffi::gtk_toggle_button_set_inconsistent(GTK_TOGGLEBUTTON(self.unwrap_widget()), to_gboolean(setting)); }
     }
 

--- a/src/traits/toggle_tool_button.rs
+++ b/src/traits/toggle_tool_button.rs
@@ -27,7 +27,7 @@ pub trait ToggleToolButtonTrait: ::WidgetTrait +
         unsafe { to_bool(ffi::gtk_toggle_tool_button_get_active(GTK_TOGGLETOOLBUTTON(self.unwrap_widget()))) }
     }
 
-    fn set_active(&mut self, set_underline: bool) -> () {
+    fn set_active(&self, set_underline: bool) -> () {
          unsafe { ffi::gtk_toggle_tool_button_set_active(GTK_TOGGLETOOLBUTTON(self.unwrap_widget()), to_gboolean(set_underline)); }
     }
 }

--- a/src/traits/tool_button.rs
+++ b/src/traits/tool_button.rs
@@ -19,19 +19,19 @@ use ffi;
 use glib::{to_bool, to_gboolean};
 
 pub trait ToolButtonTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait + ::ToolItemTrait {
-    fn set_label(&mut self, label: &str) -> () {
+    fn set_label(&self, label: &str) -> () {
         unsafe {
             ffi::gtk_tool_button_set_label(GTK_TOOLBUTTON(self.unwrap_widget()), label.borrow_to_glib().0)
         }
     }
 
-    fn set_stock_id(&mut self, stock_id: &str) -> () {
+    fn set_stock_id(&self, stock_id: &str) -> () {
         unsafe {
             ffi::gtk_tool_button_set_stock_id(GTK_TOOLBUTTON(self.unwrap_widget()), stock_id.borrow_to_glib().0)
         }
     }
 
-    fn set_icon_name(&mut self, icon_name: &str) -> () {
+    fn set_icon_name(&self, icon_name: &str) -> () {
         unsafe {
             ffi::gtk_tool_button_set_icon_name(GTK_TOOLBUTTON(self.unwrap_widget()),
                                                icon_name.borrow_to_glib().0);
@@ -63,11 +63,11 @@ pub trait ToolButtonTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait + ::Too
         unsafe { to_bool(ffi::gtk_tool_button_get_use_underline(GTK_TOOLBUTTON(self.unwrap_widget()))) }
     }
 
-    fn set_use_underline(&mut self, set_underline: bool) -> () {
+    fn set_use_underline(&self, set_underline: bool) -> () {
          unsafe { ffi::gtk_tool_button_set_use_underline(GTK_TOOLBUTTON(self.unwrap_widget()), to_gboolean(set_underline)); }
     }
 
-    fn set_label_widget<T: ::LabelTrait>(&mut self, label: &T) -> () {
+    fn set_label_widget<T: ::LabelTrait>(&self, label: &T) -> () {
         unsafe {
             ffi::gtk_tool_button_set_label_widget(GTK_TOOLBUTTON(self.unwrap_widget()), label.unwrap_widget())
         }

--- a/src/traits/tool_item.rs
+++ b/src/traits/tool_item.rs
@@ -20,7 +20,7 @@ use cast::GTK_TOOLITEM;
 use {IconSize, Orientation, ReliefStyle, ToolbarStyle};
 
 pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
-    fn set_homogeneous(&mut self, homogeneous: bool) -> () {
+    fn set_homogeneous(&self, homogeneous: bool) -> () {
          unsafe { ffi::gtk_tool_item_set_homogeneous(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(homogeneous)); }
     }
 
@@ -28,7 +28,7 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         unsafe { to_bool(ffi::gtk_tool_item_get_homogeneous(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
-    fn set_expand(&mut self, expand: bool) -> () {
+    fn set_expand(&self, expand: bool) -> () {
          unsafe { ffi::gtk_tool_item_set_expand(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(expand)); }
     }
 
@@ -36,7 +36,7 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         unsafe { to_bool(ffi::gtk_tool_item_get_expand(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
-    fn set_use_drag_window(&mut self, use_drag_window: bool) -> () {
+    fn set_use_drag_window(&self, use_drag_window: bool) -> () {
          unsafe { ffi::gtk_tool_item_set_use_drag_window(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(use_drag_window)); }
     }
 
@@ -44,7 +44,7 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         unsafe { to_bool(ffi::gtk_tool_item_get_use_drag_window(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
-    fn set_visible_horizontal(&mut self, visible_horizontal: bool) -> () {
+    fn set_visible_horizontal(&self, visible_horizontal: bool) -> () {
          unsafe { ffi::gtk_tool_item_set_visible_horizontal(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(visible_horizontal)); }
     }
 
@@ -52,7 +52,7 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         unsafe { to_bool(ffi::gtk_tool_item_get_visible_horizontal(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
-    fn set_visible_vertical(&mut self, visible_vertical: bool) -> () {
+    fn set_visible_vertical(&self, visible_vertical: bool) -> () {
          unsafe { ffi::gtk_tool_item_set_visible_vertical(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(visible_vertical)); }
     }
 
@@ -60,7 +60,7 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         unsafe { to_bool(ffi::gtk_tool_item_get_visible_vertical(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
-    fn set_is_important(&mut self, is_important: bool) -> () {
+    fn set_is_important(&self, is_important: bool) -> () {
          unsafe { ffi::gtk_tool_item_set_is_important(GTK_TOOLITEM(self.unwrap_widget()), to_gboolean(is_important)); }
     }
 
@@ -68,14 +68,14 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         unsafe { to_bool(ffi::gtk_tool_item_get_is_important(GTK_TOOLITEM(self.unwrap_widget()))) }
     }
 
-    fn set_tooltip_text(&mut self, text: &str) -> () {
+    fn set_tooltip_text(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_tool_item_set_tooltip_text(GTK_TOOLITEM(self.unwrap_widget()),
                                                 text.borrow_to_glib().0)
         }
     }
 
-    fn set_tooltip_markup(&mut self, markup: &str) -> () {
+    fn set_tooltip_markup(&self, markup: &str) -> () {
         unsafe {
             ffi::gtk_tool_item_set_tooltip_markup(GTK_TOOLITEM(self.unwrap_widget()), markup.borrow_to_glib().0)
         }
@@ -117,13 +117,13 @@ pub trait ToolItemTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait {
         }
     }
 
-    fn rebuild_menu(&mut self) -> () {
+    fn rebuild_menu(&self) -> () {
         unsafe {
             ffi::gtk_tool_item_rebuild_menu(GTK_TOOLITEM(self.unwrap_widget()))
         }
     }
 
-    fn toolbar_reconfigured(&mut self) -> () {
+    fn toolbar_reconfigured(&self) -> () {
         unsafe {
             ffi::gtk_tool_item_toolbar_reconfigured(GTK_TOOLITEM(self.unwrap_widget()))
         }

--- a/src/traits/tool_shell.rs
+++ b/src/traits/tool_shell.rs
@@ -54,7 +54,7 @@ pub trait ToolShellTrait: ::WidgetTrait {
         }
     }
 
-    fn rebuild_menu(&mut self) -> () {
+    fn rebuild_menu(&self) -> () {
         unsafe {
             ffi::gtk_tool_shell_rebuild_menu(GTK_TOOLSHELL(self.unwrap_widget()))
         }

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -23,7 +23,7 @@ use glib;
 use glib::ffi::GType;
 
 pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
-    fn show_all(&mut self) -> () {
+    fn show_all(&self) -> () {
         unsafe {
             ffi::gtk_widget_show_all(self.unwrap_widget());
         }
@@ -482,25 +482,25 @@ pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
         unsafe { ffi::gtk_widget_get_opacity(self.unwrap_widget()) }
     }
 
-    fn set_margin_top(&mut self, margin: i32) -> () {
+    fn set_margin_top(&self, margin: i32) -> () {
         unsafe {
             ffi::gtk_widget_set_margin_top(self.unwrap_widget(), margin as c_int)
         }
     }
 
-    fn set_margin_bottom(&mut self, margin: i32) -> () {
+    fn set_margin_bottom(&self, margin: i32) -> () {
         unsafe {
             ffi::gtk_widget_set_margin_bottom(self.unwrap_widget(), margin as c_int)
         }
     }
 
-    fn get_margin_top(&mut self) -> i32 {
+    fn get_margin_top(&self) -> i32 {
         unsafe {
             ffi::gtk_widget_get_margin_top(self.unwrap_widget()) as i32
         }
     }
 
-    fn get_margin_bottom(&mut self) -> i32 {
+    fn get_margin_bottom(&self) -> i32 {
         unsafe {
             ffi::gtk_widget_get_margin_bottom(self.unwrap_widget()) as i32
         }

--- a/src/traits/window.rs
+++ b/src/traits/window.rs
@@ -19,13 +19,13 @@ use glib::to_gboolean;
 use cast::GTK_WINDOW;
 
 pub trait WindowTrait : ::WidgetTrait {
-    fn set_title(&mut self, title: &str) -> () {
+    fn set_title(&self, title: &str) -> () {
         unsafe {
             ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), title.borrow_to_glib().0);
         }
     }
 
-    fn set_decorated(&mut self, setting: bool) -> () {
+    fn set_decorated(&self, setting: bool) -> () {
         unsafe {
             ffi::gtk_window_set_decorated(GTK_WINDOW(self.unwrap_widget()), to_gboolean(setting));
         }

--- a/src/widgets/action_bar.rs
+++ b/src/widgets/action_bar.rs
@@ -37,21 +37,21 @@ impl ActionBar {
         }
     }
 
-    pub fn set_center_widget<T: ::WidgetTrait>(&mut self, center_widget: &T) {
+    pub fn set_center_widget<T: ::WidgetTrait>(&self, center_widget: &T) {
         unsafe {
             ffi::gtk_action_bar_set_center_widget(GTK_ACTION_BAR(self.pointer),
                                                   center_widget.unwrap_widget())
         }
     }
 
-    pub fn pack_start<T: ::WidgetTrait>(&mut self, child: &T) {
+    pub fn pack_start<T: ::WidgetTrait>(&self, child: &T) {
         unsafe {
             ffi::gtk_action_bar_pack_start(GTK_ACTION_BAR(self.pointer),
                                            child.unwrap_widget())
         }
     }
 
-    pub fn pack_end<T: ::WidgetTrait>(&mut self, child: &T) {
+    pub fn pack_end<T: ::WidgetTrait>(&self, child: &T) {
         unsafe {
             ffi::gtk_action_bar_pack_end(GTK_ACTION_BAR(self.pointer),
                                          child.unwrap_widget())

--- a/src/widgets/adjustment.rs
+++ b/src/widgets/adjustment.rs
@@ -54,7 +54,7 @@ impl Adjustment {
         }
     }
 
-    pub fn set_value(&mut self, value: f64) -> () {
+    pub fn set_value(&self, value: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_set_value(self.pointer, value as c_double)
         }
@@ -66,7 +66,7 @@ impl Adjustment {
         }
     }
 
-    pub fn set_lower(&mut self, lower: f64) -> () {
+    pub fn set_lower(&self, lower: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_set_lower(self.pointer, lower as c_double)
         }
@@ -78,7 +78,7 @@ impl Adjustment {
         }
     }
 
-    pub fn set_page_increment(&mut self, page_increment: f64) -> () {
+    pub fn set_page_increment(&self, page_increment: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_set_page_increment(self.pointer, page_increment as c_double)
         }
@@ -90,7 +90,7 @@ impl Adjustment {
         }
     }
 
-    pub fn set_page_size(&mut self, page_size: f64) -> () {
+    pub fn set_page_size(&self, page_size: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_set_page_size(self.pointer, page_size as c_double)
         }
@@ -102,7 +102,7 @@ impl Adjustment {
         }
     }
 
-    pub fn set_step_increment(&mut self, step_increment: f64) -> () {
+    pub fn set_step_increment(&self, step_increment: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_set_step_increment(self.pointer, step_increment as c_double)
         }
@@ -114,7 +114,7 @@ impl Adjustment {
         }
     }
 
-    pub fn set_upper(&mut self, upper: f64) -> () {
+    pub fn set_upper(&self, upper: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_set_upper(self.pointer, upper as c_double)
         }
@@ -126,25 +126,25 @@ impl Adjustment {
         }
     }
 
-    pub fn clamp_page(&mut self, lower: f64, upper: f64) -> () {
+    pub fn clamp_page(&self, lower: f64, upper: f64) -> () {
         unsafe {
             ffi::gtk_adjustment_clamp_page(self.pointer, lower as c_double, upper as c_double);
         }
     }
 
-    pub fn changed(&mut self) -> () {
+    pub fn changed(&self) -> () {
         unsafe {
             ffi::gtk_adjustment_changed(self.pointer);
         }
     }
 
-    pub fn value_changed(&mut self) -> () {
+    pub fn value_changed(&self) -> () {
         unsafe {
             ffi::gtk_adjustment_value_changed(self.pointer)
         }
     }
 
-    pub fn configure(&mut self,
+    pub fn configure(&self,
                      value: f64,
                      lower: f64,
                      upper: f64,

--- a/src/widgets/alignment.rs
+++ b/src/widgets/alignment.rs
@@ -32,7 +32,7 @@ impl Alignment {
         check_pointer!(tmp_pointer, Alignment)
     }
 
-    pub fn set(&mut self,
+    pub fn set(&self,
                x_align: f32,
                y_align: f32,
                x_scale: f32,
@@ -42,7 +42,7 @@ impl Alignment {
         }
     }
 
-    pub fn set_padding(&mut self,
+    pub fn set_padding(&self,
                        padding_top: u32,
                        padding_bottom: u32,
                        padding_left: u32,

--- a/src/widgets/app_chooser_widget.rs
+++ b/src/widgets/app_chooser_widget.rs
@@ -34,7 +34,7 @@ impl AppChooserWidget {
         unsafe { ffi::gtk_app_chooser_widget_set_show_default(GTK_APP_CHOOSER_WIDGET(self.pointer), to_gboolean(setting)) }
     }
 
-    pub fn get_show_default(&mut self) -> bool {
+    pub fn get_show_default(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_app_chooser_widget_get_show_default(GTK_APP_CHOOSER_WIDGET(self.pointer)))
         }
@@ -44,7 +44,7 @@ impl AppChooserWidget {
         unsafe { ffi::gtk_app_chooser_widget_set_show_recommended(GTK_APP_CHOOSER_WIDGET(self.pointer), to_gboolean(setting)) }
     }
 
-    pub fn get_show_recommended(&mut self) -> bool {
+    pub fn get_show_recommended(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_app_chooser_widget_get_show_recommended(GTK_APP_CHOOSER_WIDGET(self.pointer)))
         }
@@ -54,7 +54,7 @@ impl AppChooserWidget {
         unsafe { ffi::gtk_app_chooser_widget_set_show_fallback(GTK_APP_CHOOSER_WIDGET(self.pointer), to_gboolean(setting)) }
     }
 
-    pub fn get_show_fallback(&mut self) -> bool {
+    pub fn get_show_fallback(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_app_chooser_widget_get_show_fallback(GTK_APP_CHOOSER_WIDGET(self.pointer)))
         }
@@ -64,7 +64,7 @@ impl AppChooserWidget {
         unsafe { ffi::gtk_app_chooser_widget_set_show_other(GTK_APP_CHOOSER_WIDGET(self.pointer), to_gboolean(setting)) }
     }
 
-    pub fn get_show_other(&mut self) -> bool {
+    pub fn get_show_other(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_app_chooser_widget_get_show_other(GTK_APP_CHOOSER_WIDGET(self.pointer)))
         }
@@ -74,7 +74,7 @@ impl AppChooserWidget {
         unsafe { ffi::gtk_app_chooser_widget_set_show_all(GTK_APP_CHOOSER_WIDGET(self.pointer), to_gboolean(setting)) }
     }
 
-    pub fn get_show_all(&mut self) -> bool {
+    pub fn get_show_all(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_app_chooser_widget_get_show_all(GTK_APP_CHOOSER_WIDGET(self.pointer)))
         }
@@ -86,7 +86,7 @@ impl AppChooserWidget {
         }
     }
 
-    pub fn get_default_text(&mut self) -> Option<String> {
+    pub fn get_default_text(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
                 ffi::gtk_app_chooser_widget_get_default_text(GTK_APP_CHOOSER_WIDGET(self.pointer)))

--- a/src/widgets/arrow.rs
+++ b/src/widgets/arrow.rs
@@ -28,7 +28,7 @@ impl Arrow {
         check_pointer!(tmp_pointer, Arrow)
     }
 
-    pub fn set(&mut self, arrow_type: ArrowType, shadow_type: ShadowType) -> () {
+    pub fn set(&self, arrow_type: ArrowType, shadow_type: ShadowType) -> () {
         unsafe {
             ffi::gtk_arrow_set(GTK_ARROW(self.pointer), arrow_type, shadow_type);
         }

--- a/src/widgets/aspect_frame.rs
+++ b/src/widgets/aspect_frame.rs
@@ -35,7 +35,7 @@ impl AspectFrame {
         check_pointer!(tmp_pointer, AspectFrame)
     }
 
-    pub fn set(&mut self,
+    pub fn set(&self,
                x_align: f32,
                y_align: f32,
                ratio: f32,

--- a/src/widgets/button_box.rs
+++ b/src/widgets/button_box.rs
@@ -43,17 +43,17 @@ impl ButtonBox {
         unsafe { to_bool(ffi::gtk_button_box_get_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.unwrap_widget())) }
     }
 
-    pub fn set_layout(&mut self, layout_style: ButtonBoxStyle) -> () {
+    pub fn set_layout(&self, layout_style: ButtonBoxStyle) -> () {
         unsafe {
             ffi::gtk_button_box_set_layout(GTK_BUTTONBOX(self.pointer), layout_style)
         }
     }
 
-    pub fn set_child_secondary<T: ::WidgetTrait + ::ButtonTrait>(&mut self, child: &T, is_secondary: bool) -> () {
+    pub fn set_child_secondary<T: ::WidgetTrait + ::ButtonTrait>(&self, child: &T, is_secondary: bool) -> () {
         unsafe { ffi::gtk_button_box_set_child_secondary(GTK_BUTTONBOX(self.pointer), child.unwrap_widget(), to_gboolean(is_secondary)); }
     }
 
-    pub fn set_child_non_homogeneous<T: ::WidgetTrait + ::ButtonTrait>(&mut self, child: &T, non_homogeneous: bool) -> () {
+    pub fn set_child_non_homogeneous<T: ::WidgetTrait + ::ButtonTrait>(&self, child: &T, non_homogeneous: bool) -> () {
         unsafe { ffi::gtk_button_box_set_child_non_homogeneous(GTK_BUTTONBOX(self.pointer), child.unwrap_widget(), to_gboolean(non_homogeneous)); }
     }
 }

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -42,25 +42,25 @@ impl Calendar {
         check_pointer!(tmp_pointer, Calendar)
     }
 
-    pub fn select_month(&mut self, month: u32, year: u32) -> () {
+    pub fn select_month(&self, month: u32, year: u32) -> () {
         unsafe {
             ffi::gtk_calendar_select_month(GTK_CALENDAR(self.pointer), month as c_uint, year as c_uint)
         }
     }
 
-    pub fn select_day(&mut self, day: u32) -> () {
+    pub fn select_day(&self, day: u32) -> () {
         unsafe {
             ffi::gtk_calendar_select_day(GTK_CALENDAR(self.pointer), day as c_uint)
         }
     }
 
-    pub fn mark_day(&mut self, day: u32) -> () {
+    pub fn mark_day(&self, day: u32) -> () {
         unsafe {
             ffi::gtk_calendar_mark_day(GTK_CALENDAR(self.pointer), day as c_uint)
         }
     }
 
-    pub fn unmark_day(&mut self, day: u32) -> () {
+    pub fn unmark_day(&self, day: u32) -> () {
         unsafe {
             ffi::gtk_calendar_unmark_day(GTK_CALENDAR(self.pointer), day as c_uint)
         }
@@ -70,7 +70,7 @@ impl Calendar {
         unsafe { to_bool(ffi::gtk_calendar_get_day_is_marked(GTK_CALENDAR(self.pointer), day as c_uint)) }
     }
 
-    pub fn clear_marks(&mut self) -> () {
+    pub fn clear_marks(&self) -> () {
         unsafe {
             ffi::gtk_calendar_clear_marks(GTK_CALENDAR(self.pointer));
         }
@@ -82,7 +82,7 @@ impl Calendar {
         }
     }
 
-    pub fn set_display_options(&mut self, flags: CalendarDisplayOptions) -> () {
+    pub fn set_display_options(&self, flags: CalendarDisplayOptions) -> () {
         unsafe {
             ffi::gtk_calendar_set_display_options(GTK_CALENDAR(self.pointer), flags)
         }
@@ -104,7 +104,7 @@ impl Calendar {
         }
     }
 
-    pub fn set_detail_with_chars(&mut self, chars: i32) -> () {
+    pub fn set_detail_with_chars(&self, chars: i32) -> () {
         unsafe {
             ffi::gtk_calendar_set_detail_width_chars(GTK_CALENDAR(self.pointer), chars as c_int)
         }
@@ -116,7 +116,7 @@ impl Calendar {
         }
     }
 
-    pub fn set_detail_heigth_rows(&mut self, rows: i32) -> () {
+    pub fn set_detail_heigth_rows(&self, rows: i32) -> () {
         unsafe {
             ffi::gtk_calendar_set_detail_height_rows(GTK_CALENDAR(self.pointer), rows as c_int)
         }

--- a/src/widgets/cell_renderer_toggle.rs
+++ b/src/widgets/cell_renderer_toggle.rs
@@ -27,28 +27,28 @@ impl CellRendererToggle {
         check_pointer!(tmp_pointer, CellRendererToggle)
     }
 
-    pub fn get_radio(&mut self) -> bool {
+    pub fn get_radio(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_cell_renderer_toggle_get_radio(
                     self.pointer as *mut ffi::C_GtkCellRendererToggle))
         }
     }
 
-    pub fn set_radio(&mut self, radio: bool) -> () {
+    pub fn set_radio(&self, radio: bool) -> () {
         unsafe {
             ffi::gtk_cell_renderer_toggle_set_radio(
                 self.pointer as *mut ffi::C_GtkCellRendererToggle, to_gboolean(radio));
         }
     }
 
-    pub fn get_active(&mut self) -> bool {
+    pub fn get_active(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_cell_renderer_toggle_get_active(
                 self.pointer as *mut ffi::C_GtkCellRendererToggle))
         }
     }
 
-    pub fn set_active(&mut self, active: bool) -> () {
+    pub fn set_active(&self, active: bool) -> () {
         unsafe {
             ffi::gtk_cell_renderer_toggle_set_active(
                 self.pointer as *mut ffi::C_GtkCellRendererToggle, to_gboolean(active));

--- a/src/widgets/color_button.rs
+++ b/src/widgets/color_button.rs
@@ -46,7 +46,7 @@ impl ColorButton {
         check_pointer!(tmp_pointer, ColorButton)
     }
 
-    pub fn set_color(&mut self, color: &gdk::Color) -> () {
+    pub fn set_color(&self, color: &gdk::Color) -> () {
         unsafe {
             ffi::gtk_color_button_set_color(GTK_COLORBUTTON(self.pointer), color)
         }
@@ -60,7 +60,7 @@ impl ColorButton {
         color
     }
 
-    pub fn set_alpha(&mut self, alpha: u16) -> () {
+    pub fn set_alpha(&self, alpha: u16) -> () {
         unsafe {
             ffi::gtk_color_button_set_alpha(GTK_COLORBUTTON(self.pointer), alpha)
         }
@@ -72,7 +72,7 @@ impl ColorButton {
         }
     }
 
-    pub fn set_rgba(&mut self, rgba: &gdk_ffi::C_GdkRGBA) -> () {
+    pub fn set_rgba(&self, rgba: &gdk_ffi::C_GdkRGBA) -> () {
         unsafe {
             ffi::gtk_color_button_set_rgba(GTK_COLORBUTTON(self.pointer), rgba)
         }
@@ -86,7 +86,7 @@ impl ColorButton {
         rgba
     }
 
-    pub fn set_use_alpha(&mut self, use_alpha: bool) -> () {
+    pub fn set_use_alpha(&self, use_alpha: bool) -> () {
         unsafe { ffi::gtk_color_button_set_use_alpha(GTK_COLORBUTTON(self.pointer), to_gboolean(use_alpha)); }
     }
 
@@ -94,7 +94,7 @@ impl ColorButton {
         unsafe { to_bool(ffi::gtk_color_button_get_use_alpha(GTK_COLORBUTTON(self.pointer))) }
     }
 
-    pub fn set_title(&mut self, title: &str) -> () {
+    pub fn set_title(&self, title: &str) -> () {
         unsafe {
             ffi::gtk_color_button_set_title(GTK_COLORBUTTON(self.pointer), title.borrow_to_glib().0);
         }

--- a/src/widgets/entry_buffer.rs
+++ b/src/widgets/entry_buffer.rs
@@ -54,7 +54,7 @@ impl EntryBuffer {
         }
     }
 
-    pub fn set_text(&mut self, text: &str) -> () {
+    pub fn set_text(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_entry_buffer_set_text(self.pointer, text.borrow_to_glib().0, -1);
         }
@@ -78,32 +78,32 @@ impl EntryBuffer {
         }
     }
 
-    pub fn set_max_length(&mut self, max_length: i32) -> () {
+    pub fn set_max_length(&self, max_length: i32) -> () {
         unsafe {
             ffi::gtk_entry_buffer_set_max_length(self.pointer, max_length as c_int)
         }
     }
 
-    pub fn insert_text(&mut self, position: u32, text: &str) -> () {
+    pub fn insert_text(&self, position: u32, text: &str) -> () {
         unsafe {
             ffi::gtk_entry_buffer_insert_text(self.pointer, position as c_uint,
                                               text.borrow_to_glib().0, -1);
         }
     }
 
-    pub fn delete_text(&mut self, position: u32, n_chars: u32) -> u32 {
+    pub fn delete_text(&self, position: u32, n_chars: u32) -> u32 {
         unsafe {
             ffi::gtk_entry_buffer_delete_text(self.pointer, position as c_uint, n_chars as c_uint) as u32
         }
     }
 
-    pub fn emit_deleted_test(&mut self, position: u32, n_chars: u32) -> () {
+    pub fn emit_deleted_test(&self, position: u32, n_chars: u32) -> () {
         unsafe {
             ffi::gtk_entry_buffer_emit_deleted_text(self.pointer, position as c_uint, n_chars as c_uint)
         }
     }
 
-    pub fn emit_inserted_text(&mut self, position: u32, text: &str) -> () {
+    pub fn emit_inserted_text(&self, position: u32, text: &str) -> () {
         unsafe {
             ffi::gtk_entry_buffer_emit_inserted_text(self.pointer, position as c_uint,
                                                      text.borrow_to_glib().0, -1);

--- a/src/widgets/event_box.rs
+++ b/src/widgets/event_box.rs
@@ -27,23 +27,23 @@ impl EventBox {
         check_pointer!(tmp_pointer, EventBox)
     }
 
-    pub fn set_above_child(&mut self, above_child: bool) {
+    pub fn set_above_child(&self, above_child: bool) {
         unsafe {
             ffi::gtk_event_box_set_above_child(GTK_EVENT_BOX(self.pointer), to_gboolean(above_child))
         }
     }
 
-    pub fn get_above_child(&mut self) -> bool {
+    pub fn get_above_child(&self) -> bool {
         unsafe { to_bool(ffi::gtk_event_box_get_above_child(GTK_EVENT_BOX(self.pointer))) }
     }
 
-    pub fn set_visible_window(&mut self, visible_window: bool) {
+    pub fn set_visible_window(&self, visible_window: bool) {
         unsafe {
             ffi::gtk_event_box_set_visible_window(GTK_EVENT_BOX(self.pointer), to_gboolean(visible_window))
         }
     }
 
-    pub fn get_visible_window(&mut self) -> bool {
+    pub fn get_visible_window(&self) -> bool {
         unsafe { to_bool(ffi::gtk_event_box_get_visible_window(GTK_EVENT_BOX(self.pointer))) }
     }
 }

--- a/src/widgets/expander.rs
+++ b/src/widgets/expander.rs
@@ -42,7 +42,7 @@ impl Expander {
     }
 
 
-    pub fn set_expanded(&mut self, expanded: bool) -> () {
+    pub fn set_expanded(&self, expanded: bool) -> () {
         unsafe { ffi::gtk_expander_set_expanded(GTK_EXPANDER(self.pointer), to_gboolean(expanded)); }
     }
 
@@ -50,7 +50,7 @@ impl Expander {
         unsafe { to_bool(ffi::gtk_expander_get_expanded(GTK_EXPANDER(self.pointer))) }
     }
 
-    pub fn set_use_underline(&mut self, use_underline: bool) -> () {
+    pub fn set_use_underline(&self, use_underline: bool) -> () {
         unsafe { ffi::gtk_expander_set_use_underline(GTK_EXPANDER(self.pointer), to_gboolean(use_underline)); }
     }
 
@@ -58,7 +58,7 @@ impl Expander {
         unsafe { to_bool(ffi::gtk_expander_get_use_underline(GTK_EXPANDER(self.pointer))) }
     }
 
-    pub fn set_use_markup(&mut self, use_markup: bool) -> () {
+    pub fn set_use_markup(&self, use_markup: bool) -> () {
         unsafe { ffi::gtk_expander_set_use_markup(GTK_EXPANDER(self.pointer), to_gboolean(use_markup)); }
     }
 
@@ -66,7 +66,7 @@ impl Expander {
         unsafe { to_bool(ffi::gtk_expander_get_use_markup(GTK_EXPANDER(self.pointer))) }
     }
 
-    pub fn set_label_fill(&mut self, label_fill: bool) -> () {
+    pub fn set_label_fill(&self, label_fill: bool) -> () {
         unsafe { ffi::gtk_expander_set_label_fill(GTK_EXPANDER(self.pointer), to_gboolean(label_fill)); }
     }
 
@@ -74,7 +74,7 @@ impl Expander {
         unsafe { to_bool(ffi::gtk_expander_get_label_fill(GTK_EXPANDER(self.pointer))) }
     }
 
-    pub fn set_resize_toplevel(&mut self, resize_toplevel: bool) -> () {
+    pub fn set_resize_toplevel(&self, resize_toplevel: bool) -> () {
         unsafe { ffi::gtk_expander_set_resize_toplevel(GTK_EXPANDER(self.pointer), to_gboolean(resize_toplevel)); }
     }
 
@@ -89,13 +89,13 @@ impl Expander {
         }
     }
 
-    pub fn set_label(&mut self, label: &str) -> () {
+    pub fn set_label(&self, label: &str) -> () {
         unsafe {
             ffi::gtk_expander_set_label(GTK_EXPANDER(self.pointer), label.borrow_to_glib().0);
         }
     }
 
-    pub fn set_spacing(&mut self, spacing: i32) -> () {
+    pub fn set_spacing(&self, spacing: i32) -> () {
         unsafe {
             ffi::gtk_expander_set_spacing(GTK_EXPANDER(self.pointer), spacing as c_int)
         }
@@ -107,13 +107,13 @@ impl Expander {
         }
     }
 
-    pub fn set_label_widget(&mut self, label: &::Label) -> () {
+    pub fn set_label_widget(&self, label: &::Label) -> () {
         unsafe {
             ffi::gtk_expander_set_label_widget(GTK_EXPANDER(self.pointer), label.unwrap_widget());
         }
     }
 
-    pub fn get_label_widget(&mut self) -> ::Label {
+    pub fn get_label_widget(&self) -> ::Label {
         unsafe {
             ::FFIWidget::wrap_widget(ffi::gtk_expander_get_label_widget(GTK_EXPANDER(self.pointer)))
         }

--- a/src/widgets/fixed.rs
+++ b/src/widgets/fixed.rs
@@ -29,7 +29,7 @@ impl Fixed {
         check_pointer!(tmp_pointer, Fixed)
     }
 
-    pub fn put<T: ::WidgetTrait>(&mut self,
+    pub fn put<T: ::WidgetTrait>(&self,
                              widget: &T,
                              x: i32,
                              y: i32) -> () {
@@ -39,7 +39,7 @@ impl Fixed {
     }
 
     // FIXME: search a new name
-    pub fn move_<T: ::WidgetTrait>(&mut self,
+    pub fn move_<T: ::WidgetTrait>(&self,
                               widget: &T,
                               x: i32,
                               y: i32) -> () {

--- a/src/widgets/flow_box.rs
+++ b/src/widgets/flow_box.rs
@@ -29,7 +29,7 @@ impl FlowBox {
         check_pointer!(tmp_pointer, FlowBox)
     }
 
-    pub fn set_homogeneous(&mut self, homogeneous: bool) {
+    pub fn set_homogeneous(&self, homogeneous: bool) {
         unsafe {
             ffi::gtk_flow_box_set_homogeneous(GTK_FLOW_BOX(self.pointer),
                                               to_gboolean(homogeneous))
@@ -48,13 +48,13 @@ impl FlowBox {
         }
     }
 
-    pub fn set_row_spacing(&mut self, spacing: u32) {
+    pub fn set_row_spacing(&self, spacing: u32) {
         unsafe {
             ffi::gtk_flow_box_set_row_spacing(GTK_FLOW_BOX(self.pointer), spacing)
         }
     }
 
-    pub fn set_colum_spacing(&mut self, spacing: u32) {
+    pub fn set_colum_spacing(&self, spacing: u32) {
         unsafe {
             ffi::gtk_flow_box_set_column_spacing(GTK_FLOW_BOX(self.pointer), spacing)
         }
@@ -66,7 +66,7 @@ impl FlowBox {
         }
     }
 
-    pub fn set_min_children_per_line(&mut self, n_children: u32) {
+    pub fn set_min_children_per_line(&self, n_children: u32) {
         unsafe {
             ffi::gtk_flow_box_set_min_children_per_line(GTK_FLOW_BOX(self.pointer), n_children)
         }
@@ -78,7 +78,7 @@ impl FlowBox {
         }
     }
 
-    pub fn set_max_children_per_line(&mut self, n_children: u32) {
+    pub fn set_max_children_per_line(&self, n_children: u32) {
         unsafe {
             ffi::gtk_flow_box_set_max_children_per_line(GTK_FLOW_BOX(self.pointer), n_children)
         }
@@ -90,7 +90,7 @@ impl FlowBox {
         }
     }
 
-    pub fn set_activate_on_single_click(&mut self, single: bool) {
+    pub fn set_activate_on_single_click(&self, single: bool) {
         unsafe {
             ffi::gtk_flow_box_set_activate_on_single_click(GTK_FLOW_BOX(self.pointer),
                                                            to_gboolean(single))
@@ -103,7 +103,7 @@ impl FlowBox {
         }
     }
 
-    pub fn insert<T: ::WidgetTrait>(&mut self, widget: &T, position: i32) {
+    pub fn insert<T: ::WidgetTrait>(&self, widget: &T, position: i32) {
         unsafe {
             ffi::gtk_flow_box_insert(GTK_FLOW_BOX(self.pointer),
                                      widget.unwrap_widget(),
@@ -122,33 +122,33 @@ impl FlowBox {
         }
     }
 
-    pub fn select_child(&mut self, child: &FlowBoxChild) {
+    pub fn select_child(&self, child: &FlowBoxChild) {
         unsafe {
             ffi::gtk_flow_box_select_child(GTK_FLOW_BOX(self.pointer),
                                            GTK_FLOW_BOX_CHILD(child.unwrap_widget()))
         }
     }
 
-    pub fn unselect_child(&mut self, child: &FlowBoxChild) {
+    pub fn unselect_child(&self, child: &FlowBoxChild) {
         unsafe {
             ffi::gtk_flow_box_unselect_child(GTK_FLOW_BOX(self.pointer),
                                              GTK_FLOW_BOX_CHILD(child.unwrap_widget()))
         }
     }
 
-    pub fn select_all(&mut self) {
+    pub fn select_all(&self) {
         unsafe {
             ffi::gtk_flow_box_select_all(GTK_FLOW_BOX(self.pointer))
         }
     }
 
-    pub fn unselect_all(&mut self) {
+    pub fn unselect_all(&self) {
         unsafe {
             ffi::gtk_flow_box_unselect_all(GTK_FLOW_BOX(self.pointer))
         }
     }
 
-    pub fn set_selection_mode(&mut self, mode: ::SelectionMode) {
+    pub fn set_selection_mode(&self, mode: ::SelectionMode) {
         unsafe {
             ffi::gtk_flow_box_set_selection_mode(GTK_FLOW_BOX(self.pointer), mode)
         }
@@ -160,14 +160,14 @@ impl FlowBox {
         }
     }
 
-    pub fn set_hadjustment(&mut self, adjustment: ::Adjustment) {
+    pub fn set_hadjustment(&self, adjustment: ::Adjustment) {
         unsafe {
             ffi::gtk_flow_box_set_hadjustment(GTK_FLOW_BOX(self.pointer),
                                               adjustment.unwrap_pointer())
         }
     }
 
-    pub fn set_vadjustment(&mut self, adjustment: ::Adjustment) {
+    pub fn set_vadjustment(&self, adjustment: ::Adjustment) {
         unsafe {
             ffi::gtk_flow_box_set_vadjustment(GTK_FLOW_BOX(self.pointer),
                                               adjustment.unwrap_pointer())
@@ -202,7 +202,7 @@ impl FlowBoxChild {
         }
     }
 
-    pub fn changed(&mut self) {
+    pub fn changed(&self) {
         unsafe {
             ffi::gtk_flow_box_child_changed(GTK_FLOW_BOX_CHILD(self.pointer))
         }

--- a/src/widgets/font_button.rs
+++ b/src/widgets/font_button.rs
@@ -40,7 +40,7 @@ impl FontButton {
         check_pointer!(tmp_pointer, FontButton)
     }
 
-    pub fn set_font_name(&mut self, font_name: &str) -> bool {
+    pub fn set_font_name(&self, font_name: &str) -> bool {
         unsafe { to_bool(ffi::gtk_font_button_set_font_name(GTK_FONTBUTTON(self.pointer), font_name.borrow_to_glib().0)) }
     }
 
@@ -51,7 +51,7 @@ impl FontButton {
         }
     }
 
-    pub fn set_show_style(&mut self, show_style: bool) -> () {
+    pub fn set_show_style(&self, show_style: bool) -> () {
         unsafe { ffi::gtk_font_button_set_show_style(GTK_FONTBUTTON(self.pointer), to_gboolean(show_style)); }
     }
 
@@ -59,7 +59,7 @@ impl FontButton {
         unsafe { to_bool(ffi::gtk_font_button_get_show_style(GTK_FONTBUTTON(self.pointer))) }
     }
 
-    pub fn set_show_size(&mut self, show_size: bool) -> () {
+    pub fn set_show_size(&self, show_size: bool) -> () {
         unsafe { ffi::gtk_font_button_set_show_size(GTK_FONTBUTTON(self.pointer), to_gboolean(show_size)); }
     }
 
@@ -67,7 +67,7 @@ impl FontButton {
         unsafe { to_bool(ffi::gtk_font_button_get_show_size(GTK_FONTBUTTON(self.pointer))) }
     }
 
-    pub fn set_use_font(&mut self, use_font: bool) -> () {
+    pub fn set_use_font(&self, use_font: bool) -> () {
         unsafe { ffi::gtk_font_button_set_use_font(GTK_FONTBUTTON(self.pointer), to_gboolean(use_font)); }
     }
 
@@ -75,7 +75,7 @@ impl FontButton {
         unsafe { to_bool(ffi::gtk_font_button_get_use_font(GTK_FONTBUTTON(self.pointer))) }
     }
 
-    pub fn set_use_size(&mut self, use_size: bool) -> () {
+    pub fn set_use_size(&self, use_size: bool) -> () {
         unsafe { ffi::gtk_font_button_set_use_size(GTK_FONTBUTTON(self.pointer), to_gboolean(use_size)); }
     }
 
@@ -83,7 +83,7 @@ impl FontButton {
         unsafe { to_bool(ffi::gtk_font_button_get_use_size(GTK_FONTBUTTON(self.pointer))) }
     }
 
-    pub fn set_title(&mut self, title: &str) -> () {
+    pub fn set_title(&self, title: &str) -> () {
         unsafe {
             ffi::gtk_font_button_set_title(GTK_FONTBUTTON(self.pointer), title.borrow_to_glib().0);
         }

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -33,7 +33,7 @@ impl Grid {
         check_pointer!(tmp_pointer, Grid)
     }
 
-    pub fn attach<T: ::WidgetTrait>(&mut self,
+    pub fn attach<T: ::WidgetTrait>(&self,
                                 child: &T,
                                 left: i32,
                                 top: i32,
@@ -49,7 +49,7 @@ impl Grid {
         }
     }
 
-    pub fn attach_next_to<T: ::WidgetTrait>(&mut self,
+    pub fn attach_next_to<T: ::WidgetTrait>(&self,
                                         child: &T,
                                         sibling: &T,
                                         side: PositionType,
@@ -65,39 +65,39 @@ impl Grid {
         }
     }
 
-    pub fn insert_row(&mut self, position: i32) -> () {
+    pub fn insert_row(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_grid_insert_row(GTK_GRID(self.pointer), position as c_int);
         }
     }
 
-     pub fn insert_column(&mut self, position: i32) -> () {
+     pub fn insert_column(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_grid_insert_column(GTK_GRID(self.pointer), position as c_int);
         }
     }
 
     #[cfg(feature = "gtk_3_10")]
-     pub fn remove_row(&mut self, position: i32) -> () {
+     pub fn remove_row(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_grid_remove_row(GTK_GRID(self.pointer), position as c_int);
         }
     }
 
     #[cfg(feature = "gtk_3_10")]
-     pub fn remove_column(&mut self, position: i32) -> () {
+     pub fn remove_column(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_grid_remove_column(GTK_GRID(self.pointer), position as c_int);
         }
     }
 
-    pub fn insert_next_to<T: ::WidgetTrait>(&mut self, sibling: &T, side: PositionType) -> () {
+    pub fn insert_next_to<T: ::WidgetTrait>(&self, sibling: &T, side: PositionType) -> () {
         unsafe {
             ffi::gtk_grid_insert_next_to(GTK_GRID(self.pointer), sibling.unwrap_widget(), side);
         }
     }
 
-    pub fn set_row_homogeneous(&mut self, homogeneous: bool) -> () {
+    pub fn set_row_homogeneous(&self, homogeneous: bool) -> () {
         unsafe { ffi::gtk_grid_set_row_homogeneous(GTK_GRID(self.pointer), to_gboolean(homogeneous)); }
     }
 
@@ -105,7 +105,7 @@ impl Grid {
         unsafe { to_bool(ffi::gtk_grid_get_row_homogeneous(GTK_GRID(self.pointer))) }
     }
 
-    pub fn set_row_spacing(&mut self, spacing: u32) -> () {
+    pub fn set_row_spacing(&self, spacing: u32) -> () {
         unsafe {
             ffi::gtk_grid_set_row_spacing(GTK_GRID(self.pointer), spacing as c_uint);
         }
@@ -117,7 +117,7 @@ impl Grid {
         }
     }
 
-    pub fn set_column_homogeneous(&mut self, homogeneous: bool) -> () {
+    pub fn set_column_homogeneous(&self, homogeneous: bool) -> () {
         unsafe { ffi::gtk_grid_set_column_homogeneous(GTK_GRID(self.pointer), to_gboolean(homogeneous)); }
     }
 
@@ -125,7 +125,7 @@ impl Grid {
         unsafe { to_bool(ffi::gtk_grid_get_column_homogeneous(GTK_GRID(self.pointer))) }
     }
 
-    pub fn set_column_spacing(&mut self, spacing: u32) -> () {
+    pub fn set_column_spacing(&self, spacing: u32) -> () {
         unsafe {
             ffi::gtk_grid_set_column_spacing(GTK_GRID(self.pointer), spacing as c_uint);
         }
@@ -145,7 +145,7 @@ impl Grid {
     }
 
     #[cfg(feature = "gtk_3_10")]
-    pub fn set_baseline_row(&mut self, row: i32) -> () {
+    pub fn set_baseline_row(&self, row: i32) -> () {
         unsafe {
             ffi::gtk_grid_set_baseline_row(GTK_GRID(self.pointer), row as c_int);
         }

--- a/src/widgets/header_bar.rs
+++ b/src/widgets/header_bar.rs
@@ -31,7 +31,7 @@ impl HeaderBar {
         check_pointer!(tmp_pointer, HeaderBar)
     }
 
-    pub fn set_title(&mut self, title: &str) {
+    pub fn set_title(&self, title: &str) {
         unsafe {
             ffi::gtk_header_bar_set_title(GTK_HEADER_BAR(self.pointer),
                                           title.borrow_to_glib().0)
@@ -45,7 +45,7 @@ impl HeaderBar {
         }
     }
 
-    pub fn set_subtitle(&mut self, subtitle: &str) {
+    pub fn set_subtitle(&self, subtitle: &str) {
         unsafe {
             ffi::gtk_header_bar_set_subtitle(GTK_HEADER_BAR(self.pointer),
                                              subtitle.borrow_to_glib().0)
@@ -59,7 +59,7 @@ impl HeaderBar {
         }
     }
 
-    pub fn set_custom_title<T: ::WidgetTrait>(&mut self, title_widget: Option<&T>) {
+    pub fn set_custom_title<T: ::WidgetTrait>(&self, title_widget: Option<&T>) {
         unsafe {
             ffi::gtk_header_bar_set_custom_title(GTK_HEADER_BAR(self.pointer),
                                                  unwrap_widget!(title_widget))
@@ -78,14 +78,14 @@ impl HeaderBar {
         }
     }
 
-    pub fn pack_start<T: ::WidgetTrait>(&mut self, child: &T) {
+    pub fn pack_start<T: ::WidgetTrait>(&self, child: &T) {
         unsafe {
             ffi::gtk_header_bar_pack_start(GTK_HEADER_BAR(self.pointer),
                                            child.unwrap_widget())
         }
     }
 
-    pub fn pack_end<T: ::WidgetTrait>(&mut self, child: &T) {
+    pub fn pack_end<T: ::WidgetTrait>(&self, child: &T) {
         unsafe {
             ffi::gtk_header_bar_pack_end(GTK_HEADER_BAR(self.pointer),
                                          child.unwrap_widget())
@@ -98,7 +98,7 @@ impl HeaderBar {
         }
     }
 
-    pub fn set_show_close_button(&mut self, setting: bool) {
+    pub fn set_show_close_button(&self, setting: bool) {
         unsafe {
             ffi::gtk_header_bar_set_show_close_button(GTK_HEADER_BAR(self.pointer),
                                                       to_gboolean(setting))

--- a/src/widgets/info_bar.rs
+++ b/src/widgets/info_bar.rs
@@ -34,49 +34,49 @@ impl InfoBar {
         check_pointer!(tmp_pointer, InfoBar)
     }
 
-    pub fn add_action_widget<T: ::WidgetTrait>(&mut self, child: &T, response_id: i32) -> () {
+    pub fn add_action_widget<T: ::WidgetTrait>(&self, child: &T, response_id: i32) -> () {
         unsafe {
             ffi::gtk_info_bar_add_action_widget(GTK_INFOBAR(self.pointer), child.unwrap_widget(), response_id as c_int)
         }
     }
 
-    pub fn add_button(&mut self, button_text: &str, response_id: i32) -> ::Button {
+    pub fn add_button(&self, button_text: &str, response_id: i32) -> ::Button {
         let button = unsafe {
             ffi::gtk_info_bar_add_button(GTK_INFOBAR(self.pointer), button_text.borrow_to_glib().0, response_id as c_int)
         };
         ::FFIWidget::wrap_widget(button)
     }
 
-    pub fn set_response_sensitive(&mut self, response_id: i32, setting: bool) -> () {
+    pub fn set_response_sensitive(&self, response_id: i32, setting: bool) -> () {
         unsafe { ffi::gtk_info_bar_set_response_sensitive(GTK_INFOBAR(self.pointer), response_id as c_int, to_gboolean(setting)); }
     }
 
-    pub fn set_default_response(&mut self, response_id: i32) -> () {
+    pub fn set_default_response(&self, response_id: i32) -> () {
         unsafe {
             ffi::gtk_info_bar_set_default_response(GTK_INFOBAR(self.pointer), response_id as c_int)
         }
     }
 
-    pub fn response(&mut self, response_id: i32) -> () {
+    pub fn response(&self, response_id: i32) -> () {
         unsafe {
             ffi::gtk_info_bar_response(GTK_INFOBAR(self.pointer), response_id as c_int)
         }
     }
 
-    pub fn set_message_type(&mut self, message_type: MessageType) -> () {
+    pub fn set_message_type(&self, message_type: MessageType) -> () {
         unsafe {
             ffi::gtk_info_bar_set_message_type(GTK_INFOBAR(self.pointer), message_type);
         }
     }
 
-    pub fn get_message_type(&mut self) -> MessageType {
+    pub fn get_message_type(&self) -> MessageType {
         unsafe {
             ffi::gtk_info_bar_get_message_type(GTK_INFOBAR(self.pointer))
         }
     }
 
     #[cfg(feature = "gtk_3_10")]
-    pub fn show_close_button(&mut self, show: bool) -> () {
+    pub fn show_close_button(&self, show: bool) -> () {
          unsafe { ffi::gtk_info_bar_set_show_close_button(GTK_INFOBAR(self.pointer), to_gboolean(show)); }
     }
 

--- a/src/widgets/layout.rs
+++ b/src/widgets/layout.rs
@@ -30,7 +30,7 @@ impl Layout {
         check_pointer!(tmp_pointer, Layout)
     }
 
-    pub fn put<T: ::WidgetTrait>(&mut self, child: &T, x: i32, y: i32) {
+    pub fn put<T: ::WidgetTrait>(&self, child: &T, x: i32, y: i32) {
         unsafe {
             ffi::gtk_layout_put(GTK_LAYOUT(self.pointer),
                                 child.unwrap_widget(),
@@ -40,7 +40,7 @@ impl Layout {
     }
 
     // FIXME: search a new name
-    pub fn move_<T: ::WidgetTrait>(&mut self, child: &T, x: i32, y: i32) {
+    pub fn move_<T: ::WidgetTrait>(&self, child: &T, x: i32, y: i32) {
         unsafe {
             ffi::gtk_layout_move(GTK_LAYOUT(self.pointer),
                                  child.unwrap_widget(),
@@ -49,13 +49,13 @@ impl Layout {
         }
     }
 
-    pub fn set_size(&mut self, width: u32, height: u32) {
+    pub fn set_size(&self, width: u32, height: u32) {
         unsafe {
             ffi::gtk_layout_set_size(GTK_LAYOUT(self.pointer), width, height)
         }
     }
 
-    pub fn get_size(&mut self) -> (u32, u32) {
+    pub fn get_size(&self) -> (u32, u32) {
         let mut width = 0;
         let mut height = 0;
 

--- a/src/widgets/level_bar.rs
+++ b/src/widgets/level_bar.rs
@@ -43,7 +43,7 @@ impl LevelBar {
         check_pointer!(tmp_pointer, LevelBar)
     }
 
-    pub fn set_value(&mut self, value: f64) -> () {
+    pub fn set_value(&self, value: f64) -> () {
         unsafe {
             ffi::gtk_level_bar_set_value(GTK_LEVELBAR(self.pointer), value as c_double);
         }
@@ -55,7 +55,7 @@ impl LevelBar {
         }
     }
 
-    pub fn set_mode(&mut self, mode: LevelBarMode) -> () {
+    pub fn set_mode(&self, mode: LevelBarMode) -> () {
         unsafe {
             ffi::gtk_level_bar_set_mode(GTK_LEVELBAR(self.pointer), mode);
         }
@@ -67,7 +67,7 @@ impl LevelBar {
         }
     }
 
-    pub fn set_min_value(&mut self, value: f64) -> () {
+    pub fn set_min_value(&self, value: f64) -> () {
         unsafe {
             ffi::gtk_level_bar_set_min_value(GTK_LEVELBAR(self.pointer), value as c_double);
         }
@@ -79,7 +79,7 @@ impl LevelBar {
         }
     }
 
-    pub fn set_max_value(&mut self, value: f64) -> () {
+    pub fn set_max_value(&self, value: f64) -> () {
         unsafe {
             ffi::gtk_level_bar_set_max_value(GTK_LEVELBAR(self.pointer), value as c_double);
         }
@@ -92,7 +92,7 @@ impl LevelBar {
     }
 
     #[cfg(feature = "gtk_3_8")]
-    pub fn set_inverted(&mut self, inverted: bool) -> () {
+    pub fn set_inverted(&self, inverted: bool) -> () {
         unsafe { ffi::gtk_level_bar_set_inverted(GTK_LEVELBAR(self.pointer), to_gboolean(inverted)); }
     }
 
@@ -101,7 +101,7 @@ impl LevelBar {
         unsafe { to_bool(ffi::gtk_level_bar_get_inverted(GTK_LEVELBAR(self.pointer))) }
     }
 
-    pub fn add_offset_value(&mut self, name: &str, value: f64) -> () {
+    pub fn add_offset_value(&self, name: &str, value: f64) -> () {
         unsafe {
             ffi::gtk_level_bar_add_offset_value(
                 GTK_LEVELBAR(self.pointer),
@@ -110,7 +110,7 @@ impl LevelBar {
         }
     }
 
-    pub fn remove_offset_value(&mut self, name: &str) -> () {
+    pub fn remove_offset_value(&self, name: &str) -> () {
         unsafe {
             ffi::gtk_level_bar_remove_offset_value(
                 GTK_LEVELBAR(self.pointer),

--- a/src/widgets/link_button.rs
+++ b/src/widgets/link_button.rs
@@ -49,13 +49,13 @@ impl LinkButton {
         }
     }
 
-    pub fn set_uri(&mut self, uri: &str) -> () {
+    pub fn set_uri(&self, uri: &str) -> () {
         unsafe {
             ffi::gtk_link_button_set_uri(GTK_LINKBUTTON(self.pointer), uri.borrow_to_glib().0)
         }
     }
 
-    pub fn set_visited(&mut self, visited: bool) -> () {
+    pub fn set_visited(&self, visited: bool) -> () {
         unsafe { ffi::gtk_link_button_set_visited(GTK_LINKBUTTON(self.pointer), to_gboolean(visited)); }
     }
 

--- a/src/widgets/list_box.rs
+++ b/src/widgets/list_box.rs
@@ -29,14 +29,14 @@ impl ListBox {
         check_pointer!(tmp_pointer, ListBox)
     }
 
-    pub fn prepend<T: ::WidgetTrait>(&mut self, child: &T) {
+    pub fn prepend<T: ::WidgetTrait>(&self, child: &T) {
         unsafe {
             ffi::gtk_list_box_prepend(GTK_LIST_BOX(self.pointer),
                                       child.unwrap_widget())
         }
     }
 
-    pub fn insert<T: ::WidgetTrait>(&mut self, child: &T, position: i32) {
+    pub fn insert<T: ::WidgetTrait>(&self, child: &T, position: i32) {
         unsafe {
             ffi::gtk_list_box_insert(GTK_LIST_BOX(self.pointer),
                                      child.unwrap_widget(),
@@ -77,21 +77,21 @@ impl ListBox {
         }
     }
 
-    pub fn select_row(&mut self, row: &ListBoxRow) {
+    pub fn select_row(&self, row: &ListBoxRow) {
         unsafe {
             ffi::gtk_list_box_select_row(GTK_LIST_BOX(self.pointer),
                                          GTK_LIST_BOX_ROW(row.unwrap_widget()))
         }
     }
 
-    pub fn set_placeholder<T: ::WidgetTrait>(&mut self, placeholder: &T) {
+    pub fn set_placeholder<T: ::WidgetTrait>(&self, placeholder: &T) {
         unsafe {
             ffi::gtk_list_box_set_placeholder(GTK_LIST_BOX(self.pointer),
                                               placeholder.unwrap_widget())
         }
     }
 
-    pub fn set_adjustment(&mut self, adjustment: &::Adjustment) {
+    pub fn set_adjustment(&self, adjustment: &::Adjustment) {
         unsafe {
             ffi::gtk_list_box_set_adjustment(GTK_LIST_BOX(self.pointer),
                                              adjustment.unwrap_pointer())
@@ -109,7 +109,7 @@ impl ListBox {
         }
     }
 
-    pub fn set_selection_mode(&mut self, mode: ::SelectionMode) {
+    pub fn set_selection_mode(&self, mode: ::SelectionMode) {
         unsafe {
             ffi::gtk_list_box_set_selection_mode(GTK_LIST_BOX(self.pointer), mode)
         }
@@ -121,13 +121,13 @@ impl ListBox {
         }
     }
 
-    pub fn invalidate_header(&mut self) {
+    pub fn invalidate_header(&self) {
         unsafe {
             ffi::gtk_list_box_invalidate_headers(GTK_LIST_BOX(self.pointer))
         }
     }
 
-    pub fn set_activate_on_single_click(&mut self, single: bool) {
+    pub fn set_activate_on_single_click(&self, single: bool) {
         unsafe {
             ffi::gtk_list_box_set_activate_on_single_click(GTK_LIST_BOX(self.pointer),
                                                            to_gboolean(single))
@@ -140,13 +140,13 @@ impl ListBox {
         }
     }
 
-    pub fn drag_unhighlight_row(&mut self) {
+    pub fn drag_unhighlight_row(&self) {
         unsafe {
             ffi::gtk_list_box_drag_unhighlight_row(GTK_LIST_BOX(self.pointer))
         }
     }
 
-    pub fn drag_highlight_row(&mut self, row: &ListBoxRow) {
+    pub fn drag_highlight_row(&self, row: &ListBoxRow) {
         unsafe {
             ffi::gtk_list_box_drag_highlight_row(GTK_LIST_BOX(self.pointer),
                                                  row.unwrap_widget() as *mut ffi::C_GtkListBoxRow)
@@ -171,7 +171,7 @@ impl ListBoxRow {
         check_pointer!(tmp_pointer, ListBoxRow)
     }
 
-    pub fn changed(&mut self) {
+    pub fn changed(&self) {
         unsafe {
             ffi::gtk_list_box_row_changed(GTK_LIST_BOX_ROW(self.pointer))
         }
@@ -189,7 +189,7 @@ impl ListBoxRow {
         }
     }
 
-    pub fn set_header<T: ::WidgetTrait>(&mut self, header: &T) {
+    pub fn set_header<T: ::WidgetTrait>(&self, header: &T) {
         unsafe {
             ffi::gtk_list_box_row_set_header(GTK_LIST_BOX_ROW(self.pointer),
                                              header.unwrap_widget())

--- a/src/widgets/menu_button.rs
+++ b/src/widgets/menu_button.rs
@@ -28,13 +28,13 @@ impl MenuButton {
         check_pointer!(tmp_pointer, MenuButton)
     }
 
-    pub fn set_popup<T: ::WidgetTrait>(&mut self, popup: &T) -> () {
+    pub fn set_popup<T: ::WidgetTrait>(&self, popup: &T) -> () {
         unsafe {
             ffi::gtk_menu_button_set_popup(GTK_MENUBUTTON(self.pointer), popup.unwrap_widget());
         }
     }
 
-    pub fn set_direction(&mut self, direction: ArrowType) -> () {
+    pub fn set_direction(&self, direction: ArrowType) -> () {
         unsafe {
             ffi::gtk_menu_button_set_direction(GTK_MENUBUTTON(self.pointer), direction);
         }
@@ -46,7 +46,7 @@ impl MenuButton {
         }
     }
 
-    pub fn set_align_widget<T: ::WidgetTrait>(&mut self, align_widget: &T) -> () {
+    pub fn set_align_widget<T: ::WidgetTrait>(&self, align_widget: &T) -> () {
         unsafe {
             ffi::gtk_menu_button_set_align_widget(GTK_MENUBUTTON(self.pointer), align_widget.unwrap_widget())
         }

--- a/src/widgets/menu_tool_button.rs
+++ b/src/widgets/menu_tool_button.rs
@@ -44,13 +44,13 @@ impl MenuToolButton {
         check_pointer!(tmp_pointer, MenuToolButton)
     }
 
-    pub fn set_arrow_tooltip_text(&mut self, text: &str) -> () {
+    pub fn set_arrow_tooltip_text(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_menu_tool_button_set_arrow_tooltip_text(GTK_MENUTOOLBUTTON(self.pointer), text.borrow_to_glib().0)
         }
     }
 
-    pub fn set_arrow_tooltip_markup(&mut self, markup: &str) -> () {
+    pub fn set_arrow_tooltip_markup(&self, markup: &str) -> () {
         unsafe {
             ffi::gtk_menu_tool_button_set_arrow_tooltip_markup(
                 GTK_MENUTOOLBUTTON(self.pointer),

--- a/src/widgets/note_book.rs
+++ b/src/widgets/note_book.rs
@@ -30,7 +30,7 @@ impl NoteBook {
         check_pointer!(tmp_pointer, NoteBook)
     }
 
-    pub fn append_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&mut self, child: &Child,
+    pub fn append_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&self, child: &Child,
             tab_label: Option<&TabLabel>) -> Option<u32> {
         match unsafe { ffi::gtk_notebook_append_page(GTK_NOTEBOOK(self.pointer),
                 child.unwrap_widget(), unwrap_widget!(tab_label)) } {
@@ -40,7 +40,7 @@ impl NoteBook {
     }
 
     pub fn append_page_menu<Child: ::WidgetTrait, TabLabel: ::WidgetTrait,
-            MenuLabel: ::WidgetTrait>(&mut self, child: &Child, tab_label: Option<&TabLabel>,
+            MenuLabel: ::WidgetTrait>(&self, child: &Child, tab_label: Option<&TabLabel>,
             menu_label: Option<&MenuLabel>) -> Option<u32> {
         match unsafe { ffi::gtk_notebook_append_page_menu(GTK_NOTEBOOK(self.pointer),
                 child.unwrap_widget(), unwrap_widget!(tab_label), unwrap_widget!(menu_label)) } {
@@ -49,7 +49,7 @@ impl NoteBook {
         }
     }
 
-    pub fn prepend_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&mut self, child: &Child,
+    pub fn prepend_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&self, child: &Child,
             tab_label: Option<&TabLabel>) -> Option<u32> {
         match unsafe { ffi::gtk_notebook_prepend_page(GTK_NOTEBOOK(self.pointer),
                 child.unwrap_widget(), unwrap_widget!(tab_label)) } {
@@ -59,7 +59,7 @@ impl NoteBook {
     }
 
     pub fn prepend_page_menu<Child: ::WidgetTrait, TabLabel: ::WidgetTrait,
-            MenuLabel: ::WidgetTrait>(&mut self, child: &Child, tab_label: Option<&TabLabel>,
+            MenuLabel: ::WidgetTrait>(&self, child: &Child, tab_label: Option<&TabLabel>,
             menu_label: Option<&MenuLabel>) -> Option<u32> {
         match unsafe { ffi::gtk_notebook_prepend_page_menu(GTK_NOTEBOOK(self.pointer),
                 child.unwrap_widget(), unwrap_widget!(tab_label), unwrap_widget!(menu_label)) } {
@@ -68,7 +68,7 @@ impl NoteBook {
         }
     }
 
-    pub fn insert_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&mut self, child: &Child,
+    pub fn insert_page<Child: ::WidgetTrait, TabLabel: ::WidgetTrait>(&self, child: &Child,
             tab_label: Option<&TabLabel>, position: i32) -> Option<u32> {
         match unsafe { ffi::gtk_notebook_insert_page(GTK_NOTEBOOK(self.pointer),
                 child.unwrap_widget(), unwrap_widget!(tab_label), position) } {
@@ -78,7 +78,7 @@ impl NoteBook {
     }
 
     pub fn insert_page_menu<Child: ::WidgetTrait, TabLabel: ::WidgetTrait,
-            MenuLabel: ::WidgetTrait>(&mut self, child: &Child, tab_label: Option<&TabLabel>,
+            MenuLabel: ::WidgetTrait>(&self, child: &Child, tab_label: Option<&TabLabel>,
             menu_label: Option<&MenuLabel>, position: i32) -> Option<u32> {
         match unsafe { ffi::gtk_notebook_insert_page_menu(GTK_NOTEBOOK(self.pointer),
                 child.unwrap_widget(), unwrap_widget!(tab_label), unwrap_widget!(menu_label),
@@ -88,20 +88,20 @@ impl NoteBook {
         }
     }
 
-    pub fn remove_page(&mut self, page_num: i32) {
+    pub fn remove_page(&self, page_num: i32) {
         unsafe {
             ffi::gtk_notebook_remove_page(GTK_NOTEBOOK(self.pointer), page_num)
         }
     }
 
-    pub fn set_group_name(&mut self, group_name: &str) {
+    pub fn set_group_name(&self, group_name: &str) {
         unsafe {
             ffi::gtk_notebook_set_group_name(GTK_NOTEBOOK(self.pointer),
                                              group_name.borrow_to_glib().0)
         }
     }
 
-    pub fn get_group_name(&mut self) -> Option<String> {
+    pub fn get_group_name(&self) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
                 ffi::gtk_notebook_get_group_name(GTK_NOTEBOOK(self.pointer)))
@@ -136,25 +136,25 @@ impl NoteBook {
         }
     }
 
-    pub fn set_current_page(&mut self, page_num: i32) {
+    pub fn set_current_page(&self, page_num: i32) {
         unsafe {
             ffi::gtk_notebook_set_current_page(GTK_NOTEBOOK(self.pointer), page_num)
         }
     }
 
-    pub fn next_page(&mut self) {
+    pub fn next_page(&self) {
         unsafe {
             ffi::gtk_notebook_next_page(GTK_NOTEBOOK(self.pointer))
         }
     }
 
-    pub fn prev_page(&mut self) {
+    pub fn prev_page(&self) {
         unsafe {
             ffi::gtk_notebook_prev_page(GTK_NOTEBOOK(self.pointer))
         }
     }
 
-    pub fn set_show_border(&mut self, show_border: bool) {
+    pub fn set_show_border(&self, show_border: bool) {
         unsafe {
             ffi::gtk_notebook_set_show_border(GTK_NOTEBOOK(self.pointer),
                                               to_gboolean(show_border))
@@ -167,7 +167,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_show_tabs(&mut self, show_tabs: bool) {
+    pub fn set_show_tabs(&self, show_tabs: bool) {
         unsafe {
             ffi::gtk_notebook_set_show_tabs(GTK_NOTEBOOK(self.pointer),
                                             to_gboolean(show_tabs))
@@ -180,7 +180,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_tab_pos(&mut self, pos: ::PositionType) {
+    pub fn set_tab_pos(&self, pos: ::PositionType) {
         unsafe {
             ffi::gtk_notebook_set_tab_pos(GTK_NOTEBOOK(self.pointer), pos)
         }
@@ -192,7 +192,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_scrollable(&mut self, scrollable: bool) {
+    pub fn set_scrollable(&self, scrollable: bool) {
         unsafe {
             ffi::gtk_notebook_set_scrollable(GTK_NOTEBOOK(self.pointer),
                                              to_gboolean(scrollable))
@@ -217,13 +217,13 @@ impl NoteBook {
         }
     }
 
-    pub fn popup_enable(&mut self) {
+    pub fn popup_enable(&self) {
         unsafe {
             ffi::gtk_notebook_popup_enable(GTK_NOTEBOOK(self.pointer))
         }
     }
 
-    pub fn popup_disable(&mut self) {
+    pub fn popup_disable(&self) {
         unsafe {
             ffi::gtk_notebook_popup_disable(GTK_NOTEBOOK(self.pointer))
         }
@@ -251,7 +251,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_tab_label_text<T: ::WidgetTrait>(&mut self, child: &T, tab_text: &str) {
+    pub fn set_tab_label_text<T: ::WidgetTrait>(&self, child: &T, tab_text: &str) {
         unsafe {
             ffi::gtk_notebook_set_tab_label_text(GTK_NOTEBOOK(self.pointer),
                                                  child.unwrap_widget(),
@@ -259,7 +259,7 @@ impl NoteBook {
         }
     }
 
-    pub fn get_tab_label_text<T: ::WidgetTrait>(&mut self, child: &T) -> Option<String> {
+    pub fn get_tab_label_text<T: ::WidgetTrait>(&self, child: &T) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
                 ffi::gtk_notebook_get_tab_label_text(GTK_NOTEBOOK(self.pointer),
@@ -289,7 +289,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_menu_label_text<T: ::WidgetTrait>(&mut self, child: &T, tab_text: &str) {
+    pub fn set_menu_label_text<T: ::WidgetTrait>(&self, child: &T, tab_text: &str) {
         unsafe {
             ffi::gtk_notebook_set_menu_label_text(GTK_NOTEBOOK(self.pointer),
                                                   child.unwrap_widget(),
@@ -297,7 +297,7 @@ impl NoteBook {
         }
     }
 
-    pub fn get_menu_label_text<T: ::WidgetTrait>(&mut self, child: &T) -> Option<String> {
+    pub fn get_menu_label_text<T: ::WidgetTrait>(&self, child: &T) -> Option<String> {
         unsafe {
             FromGlibPtr::borrow(
                 ffi::gtk_notebook_get_menu_label_text(GTK_NOTEBOOK(self.pointer),
@@ -305,7 +305,7 @@ impl NoteBook {
         }
     }
 
-    pub fn reorder_child<T: ::WidgetTrait>(&mut self, child: &T, position: i32) {
+    pub fn reorder_child<T: ::WidgetTrait>(&self, child: &T, position: i32) {
         unsafe {
             ffi::gtk_notebook_reorder_child(GTK_NOTEBOOK(self.pointer),
                                             child.unwrap_widget(),
@@ -320,7 +320,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_tab_reorderable<T: ::WidgetTrait>(&mut self, child: &T, reorderable: bool) {
+    pub fn set_tab_reorderable<T: ::WidgetTrait>(&self, child: &T, reorderable: bool) {
         unsafe {
             ffi::gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(self.pointer),
                                                  child.unwrap_widget(),
@@ -335,7 +335,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_tab_detachable<T: ::WidgetTrait>(&mut self, child: &T, detachable: bool) {
+    pub fn set_tab_detachable<T: ::WidgetTrait>(&self, child: &T, detachable: bool) {
         unsafe {
             ffi::gtk_notebook_set_tab_detachable(GTK_NOTEBOOK(self.pointer),
                                                 child.unwrap_widget(),
@@ -353,7 +353,7 @@ impl NoteBook {
         }
     }
 
-    pub fn set_action_widget<T: ::WidgetTrait>(&mut self, child: &T, pack_type: ::PackType) {
+    pub fn set_action_widget<T: ::WidgetTrait>(&self, child: &T, pack_type: ::PackType) {
         unsafe {
             ffi::gtk_notebook_set_action_widget(GTK_NOTEBOOK(self.pointer),
                                                 child.unwrap_widget(),

--- a/src/widgets/overlay.rs
+++ b/src/widgets/overlay.rs
@@ -27,7 +27,7 @@ impl Overlay {
         check_pointer!(tmp_pointer, Overlay)
     }
 
-    pub fn add_overlay<T: ::WidgetTrait>(&mut self, widget: &T) {
+    pub fn add_overlay<T: ::WidgetTrait>(&self, widget: &T) {
         unsafe {
             ffi::gtk_overlay_add_overlay(GTK_OVERLAY(self.pointer), widget.unwrap_widget())
         }

--- a/src/widgets/paned.rs
+++ b/src/widgets/paned.rs
@@ -40,33 +40,33 @@ impl Paned {
         check_pointer!(tmp_pointer, Paned)
     }
 
-    pub fn add1<T: ::WidgetTrait>(&mut self, child: &T) -> () {
+    pub fn add1<T: ::WidgetTrait>(&self, child: &T) -> () {
         unsafe {
             ffi::gtk_paned_add1(GTK_PANED(self.pointer), child.unwrap_widget())
         }
     }
 
-    pub fn add2<T: ::WidgetTrait>(&mut self, child: &T) -> () {
+    pub fn add2<T: ::WidgetTrait>(&self, child: &T) -> () {
         unsafe {
             ffi::gtk_paned_add2(GTK_PANED(self.pointer), child.unwrap_widget())
         }
     }
 
-    pub fn pack1<T: ::WidgetTrait>(&mut self, child: &T, resize: bool, schrink: bool) -> () {
+    pub fn pack1<T: ::WidgetTrait>(&self, child: &T, resize: bool, schrink: bool) -> () {
         unsafe {
             ffi::gtk_paned_pack1(GTK_PANED(self.pointer), child.unwrap_widget(),
                                  to_gboolean(resize), to_gboolean(schrink));
         }
     }
 
-    pub fn pack2<T: ::WidgetTrait>(&mut self, child: &T, resize: bool, schrink: bool) -> () {
+    pub fn pack2<T: ::WidgetTrait>(&self, child: &T, resize: bool, schrink: bool) -> () {
         unsafe {
             ffi::gtk_paned_pack2(GTK_PANED(self.pointer), child.unwrap_widget(),
                                  to_gboolean(resize), to_gboolean(schrink));
         }
     }
 
-    pub fn set_position(&mut self, position: i32) -> () {
+    pub fn set_position(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_paned_set_position(GTK_PANED(self.pointer), position as c_int);
         }

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -31,13 +31,13 @@ impl ProgressBar {
         check_pointer!(tmp_pointer, ProgressBar)
     }
 
-    pub fn pulse(&mut self) -> () {
+    pub fn pulse(&self) -> () {
         unsafe {
             ffi::gtk_progress_bar_pulse(GTK_PROGRESSBAR(self.pointer))
         }
     }
 
-    pub fn set_fraction(&mut self, fraction: f64) -> () {
+    pub fn set_fraction(&self, fraction: f64) -> () {
         unsafe {
             ffi::gtk_progress_bar_set_fraction(GTK_PROGRESSBAR(self.pointer), fraction as c_double)
         }
@@ -49,7 +49,7 @@ impl ProgressBar {
         }
     }
 
-    pub fn set_text(&mut self, text: &str) -> () {
+    pub fn set_text(&self, text: &str) -> () {
         unsafe {
             ffi::gtk_progress_bar_set_text(GTK_PROGRESSBAR(self.pointer), text.borrow_to_glib().0);
         }
@@ -62,7 +62,7 @@ impl ProgressBar {
         }
     }
 
-    pub fn set_inverted(&mut self, inverted: bool) -> () {
+    pub fn set_inverted(&self, inverted: bool) -> () {
         unsafe { ffi::gtk_progress_bar_set_inverted(GTK_PROGRESSBAR(self.pointer), to_gboolean(inverted)); }
     }
 
@@ -70,7 +70,7 @@ impl ProgressBar {
         unsafe { to_bool(ffi::gtk_progress_bar_get_inverted(GTK_PROGRESSBAR(self.pointer))) }
     }
 
-    pub fn set_show_text(&mut self, show_text: bool) -> () {
+    pub fn set_show_text(&self, show_text: bool) -> () {
         unsafe { ffi::gtk_progress_bar_set_show_text(GTK_PROGRESSBAR(self.pointer), to_gboolean(show_text)); }
     }
 
@@ -78,7 +78,7 @@ impl ProgressBar {
         unsafe { to_bool(ffi::gtk_progress_bar_get_show_text(GTK_PROGRESSBAR(self.pointer))) }
     }
 
-    pub fn set_pulse_step(&mut self, pulse_step: f64) -> () {
+    pub fn set_pulse_step(&self, pulse_step: f64) -> () {
         unsafe {
             ffi::gtk_progress_bar_set_pulse_step(GTK_PROGRESSBAR(self.pointer), pulse_step as c_double)
         }

--- a/src/widgets/radio_button.rs
+++ b/src/widgets/radio_button.rs
@@ -46,7 +46,7 @@ impl RadioButton {
         check_pointer!(tmp_pointer, RadioButton)
     }
 
-    pub fn join(&mut self, group_source: &mut RadioButton) {
+    pub fn join(&self, group_source: &RadioButton) {
         unsafe {
             ffi::gtk_radio_button_join_group(GTK_RADIOBUTTON(self.pointer),
                                              GTK_RADIOBUTTON(group_source.pointer));

--- a/src/widgets/revealer.rs
+++ b/src/widgets/revealer.rs
@@ -34,7 +34,7 @@ impl Revealer {
         }
     }
 
-    pub fn set_reveal_child(&mut self, reveal_child: bool) {
+    pub fn set_reveal_child(&self, reveal_child: bool) {
         unsafe {
             ffi::gtk_revealer_set_reveal_child(GTK_REVEALER(self.pointer),
                                                to_gboolean(reveal_child))
@@ -53,13 +53,13 @@ impl Revealer {
         }
     }
 
-    pub fn set_transition_duration(&mut self, duration: u32) {
+    pub fn set_transition_duration(&self, duration: u32) {
         unsafe {
             ffi::gtk_revealer_set_transition_duration(GTK_REVEALER(self.pointer), duration)
         }
     }
 
-    pub fn set_transition_type(&mut self, transition: ::RevealerTransitionType) {
+    pub fn set_transition_type(&self, transition: ::RevealerTransitionType) {
         unsafe {
             ffi::gtk_revealer_set_transition_type(GTK_REVEALER(self.pointer), transition)
         }

--- a/src/widgets/scale.rs
+++ b/src/widgets/scale.rs
@@ -45,13 +45,13 @@ impl Scale {
         check_pointer!(tmp_pointer, Scale)
     }
 
-    pub fn set_digits(&mut self, digits: i32) -> () {
+    pub fn set_digits(&self, digits: i32) -> () {
         unsafe {
             ffi::gtk_scale_set_digits(GTK_SCALE(self.pointer), digits as c_int);
         }
     }
 
-    pub fn set_draw_value(&mut self, draw_value: bool) -> () {
+    pub fn set_draw_value(&self, draw_value: bool) -> () {
         unsafe { ffi::gtk_scale_set_draw_value(GTK_SCALE(self.pointer), to_gboolean(draw_value)); }
     }
 
@@ -59,7 +59,7 @@ impl Scale {
         unsafe { to_bool(ffi::gtk_scale_get_draw_value(GTK_SCALE(self.pointer))) }
     }
 
-    pub fn set_has_origin(&mut self, has_origin: bool) -> () {
+    pub fn set_has_origin(&self, has_origin: bool) -> () {
         unsafe { ffi::gtk_scale_set_has_origin(GTK_SCALE(self.pointer), to_gboolean(has_origin)); }
     }
 
@@ -67,7 +67,7 @@ impl Scale {
         unsafe { to_bool(ffi::gtk_scale_get_has_origin(GTK_SCALE(self.pointer))) }
     }
 
-    pub fn set_value_pos(&mut self, position: PositionType) -> () {
+    pub fn set_value_pos(&self, position: PositionType) -> () {
         unsafe {
             ffi::gtk_scale_set_value_pos(GTK_SCALE(self.pointer), position);
         }
@@ -95,13 +95,13 @@ impl Scale {
         (x, y)
     }
 
-    pub fn add_mark(&mut self, value: f64, position: PositionType, markup: &str) -> () {
+    pub fn add_mark(&self, value: f64, position: PositionType, markup: &str) -> () {
         unsafe {
             ffi::gtk_scale_add_mark(GTK_SCALE(self.pointer), value as c_double, position, markup.borrow_to_glib().0);
         }
     }
 
-    pub fn clear_marks(&mut self) -> () {
+    pub fn clear_marks(&self) -> () {
         unsafe {
             ffi::gtk_scale_clear_marks(GTK_SCALE(self.pointer))
         }

--- a/src/widgets/search_bar.rs
+++ b/src/widgets/search_bar.rs
@@ -29,13 +29,13 @@ impl SearchBar {
         check_pointer!(tmp_pointer, SearchBar)
     }
 
-    pub fn connect_entry(&mut self, entry: &::Entry) -> () {
+    pub fn connect_entry(&self, entry: &::Entry) -> () {
         unsafe {
             ffi::gtk_search_bar_connect_entry(GTK_SEARCHBAR(self.pointer), GTK_ENTRY(entry.unwrap_widget()));
         }
     }
 
-    pub fn set_search_mode(&mut self, search_mode: bool) -> () {
+    pub fn set_search_mode(&self, search_mode: bool) -> () {
         unsafe { ffi::gtk_search_bar_set_search_mode(GTK_SEARCHBAR(self.pointer), to_gboolean(search_mode)); }
     }
 
@@ -43,7 +43,7 @@ impl SearchBar {
         unsafe { to_bool(ffi::gtk_search_bar_get_search_mode(GTK_SEARCHBAR(self.pointer))) }
     }
 
-    pub fn set_show_close_button(&mut self, visible: bool) -> () {
+    pub fn set_show_close_button(&self, visible: bool) -> () {
         unsafe { ffi::gtk_search_bar_set_show_close_button(GTK_SEARCHBAR(self.pointer), to_gboolean(visible)); }
     }
 

--- a/src/widgets/separator_tool_item.rs
+++ b/src/widgets/separator_tool_item.rs
@@ -28,7 +28,7 @@ impl SeparatorToolItem {
         check_pointer!(tmp_pointer, SeparatorToolItem)
     }
 
-    pub fn set_draw(&mut self, draw: bool) -> () {
+    pub fn set_draw(&self, draw: bool) -> () {
         unsafe { ffi::gtk_separator_tool_item_set_draw(GTK_SEPARATORTOOLITEM(self.pointer), to_gboolean(draw)); }
     }
 

--- a/src/widgets/spin_button.rs
+++ b/src/widgets/spin_button.rs
@@ -47,13 +47,13 @@ impl SpinButton {
         check_pointer!(tmp_pointer, SpinButton)
     }
 
-    pub fn configure(&mut self, adjustment: &::Adjustment, climb_rate: f64, digits: u32) -> () {
+    pub fn configure(&self, adjustment: &::Adjustment, climb_rate: f64, digits: u32) -> () {
         unsafe {
             ffi::gtk_spin_button_configure(GTK_SPINBUTTON(self.pointer), adjustment.unwrap_pointer(), climb_rate as c_double, digits as c_uint);
         }
     }
 
-    pub fn set_adjustment(&mut self, adjustment: &::Adjustment) -> () {
+    pub fn set_adjustment(&self, adjustment: &::Adjustment) -> () {
         unsafe {
             ffi:: gtk_spin_button_set_adjustment(GTK_SPINBUTTON(self.pointer), adjustment.unwrap_pointer());
         }
@@ -65,19 +65,19 @@ impl SpinButton {
         }
     }
 
-    pub fn set_digits(&mut self, digits: u32) -> () {
+    pub fn set_digits(&self, digits: u32) -> () {
         unsafe {
             ffi::gtk_spin_button_set_digits(GTK_SPINBUTTON(self.pointer), digits as c_uint);
         }
     }
 
-    pub fn set_increments(&mut self, step: f64, page: f64) -> () {
+    pub fn set_increments(&self, step: f64, page: f64) -> () {
         unsafe {
             ffi::gtk_spin_button_set_increments(GTK_SPINBUTTON(self.pointer), step as c_double, page as c_double);
         }
     }
 
-    pub fn set_range(&mut self, min: f64, max: f64) -> () {
+    pub fn set_range(&self, min: f64, max: f64) -> () {
         unsafe {
             ffi::gtk_spin_button_set_range(GTK_SPINBUTTON(self.pointer), min as c_double, max as c_double);
         }
@@ -89,19 +89,19 @@ impl SpinButton {
         }
     }
 
-    pub fn set_value(&mut self, value: f64) -> () {
+    pub fn set_value(&self, value: f64) -> () {
         unsafe {
             ffi::gtk_spin_button_set_value(GTK_SPINBUTTON(self.pointer), value as c_double);
         }
     }
 
-    pub fn set_update_policy(&mut self, policy: SpinButtonUpdatePolicy) -> () {
+    pub fn set_update_policy(&self, policy: SpinButtonUpdatePolicy) -> () {
         unsafe {
             ffi::gtk_spin_button_set_update_policy(GTK_SPINBUTTON(self.pointer), policy);
         }
     }
 
-    pub fn set_numeric(&mut self, numeric: bool) -> () {
+    pub fn set_numeric(&self, numeric: bool) -> () {
         unsafe { ffi::gtk_spin_button_set_numeric(GTK_SPINBUTTON(self.pointer), to_gboolean(numeric)); }
     }
 
@@ -109,7 +109,7 @@ impl SpinButton {
         unsafe { to_bool(ffi::gtk_spin_button_get_numeric(GTK_SPINBUTTON(self.pointer))) }
     }
 
-    pub fn set_wrap(&mut self, wrap: bool) -> () {
+    pub fn set_wrap(&self, wrap: bool) -> () {
         unsafe { ffi::gtk_spin_button_set_wrap(GTK_SPINBUTTON(self.pointer), to_gboolean(wrap)); }
     }
 
@@ -117,7 +117,7 @@ impl SpinButton {
         unsafe { to_bool(ffi::gtk_spin_button_get_wrap(GTK_SPINBUTTON(self.pointer))) }
     }
 
-    pub fn set_snap_to_ticks(&mut self, snap_to_ticks: bool) -> () {
+    pub fn set_snap_to_ticks(&self, snap_to_ticks: bool) -> () {
         unsafe { ffi::gtk_spin_button_set_snap_to_ticks(GTK_SPINBUTTON(self.pointer), to_gboolean(snap_to_ticks)); }
     }
 
@@ -125,7 +125,7 @@ impl SpinButton {
         unsafe { to_bool(ffi::gtk_spin_button_get_snap_to_ticks(GTK_SPINBUTTON(self.pointer))) }
     }
 
-    pub fn spin(&mut self, direction: SpinType, increment: f64) -> () {
+    pub fn spin(&self, direction: SpinType, increment: f64) -> () {
         unsafe {
             ffi::gtk_spin_button_spin(GTK_SPINBUTTON(self.pointer), direction, increment as c_double);
         }

--- a/src/widgets/spinner.rs
+++ b/src/widgets/spinner.rs
@@ -27,13 +27,13 @@ impl Spinner {
         check_pointer!(tmp_pointer, Spinner)
     }
 
-    pub fn start(&mut self) -> () {
+    pub fn start(&self) -> () {
         unsafe {
             ffi::gtk_spinner_start(GTK_SPINNER(self.pointer))
         }
     }
 
-    pub fn stop(&mut self) -> () {
+    pub fn stop(&self) -> () {
         unsafe {
             ffi::gtk_spinner_stop(GTK_SPINNER(self.pointer))
         }

--- a/src/widgets/stack.rs
+++ b/src/widgets/stack.rs
@@ -31,7 +31,7 @@ impl Stack {
         check_pointer!(tmp_pointer, Stack)
     }
 
-    pub fn add_named<T: ::WidgetTrait>(&mut self, child: &T, name: &str) {
+    pub fn add_named<T: ::WidgetTrait>(&self, child: &T, name: &str) {
         unsafe {
             ffi::gtk_stack_add_named(GTK_STACK(self.pointer),
                                      child.unwrap_widget(),
@@ -39,7 +39,7 @@ impl Stack {
         }
     }
 
-    pub fn add_titled<T: ::WidgetTrait>(&mut self, child: &T, name: &str, title: &str) {
+    pub fn add_titled<T: ::WidgetTrait>(&self, child: &T, name: &str, title: &str) {
         unsafe {
             ffi::gtk_stack_add_titled(GTK_STACK(self.pointer),
                                       child.unwrap_widget(),
@@ -48,7 +48,7 @@ impl Stack {
         }
     }
 
-    pub fn set_visible_child<T: ::WidgetTrait>(&mut self, child: &T) {
+    pub fn set_visible_child<T: ::WidgetTrait>(&self, child: &T) {
         unsafe {
             ffi::gtk_stack_set_visible_child(GTK_STACK(self.pointer),
                                              child.unwrap_widget())
@@ -64,7 +64,7 @@ impl Stack {
         }
     }
 
-    pub fn set_visible_child_name(&mut self, name: &str) {
+    pub fn set_visible_child_name(&self, name: &str) {
         unsafe {
             ffi::gtk_stack_set_visible_child_name(GTK_STACK(self.pointer),
                                                   name.borrow_to_glib().0)
@@ -78,7 +78,7 @@ impl Stack {
         }
     }
 
-    pub fn set_visible_child_full(&mut self, name: &str, transition: ::StackTransitionType) {
+    pub fn set_visible_child_full(&self, name: &str, transition: ::StackTransitionType) {
         unsafe {
             ffi::gtk_stack_set_visible_child_full(GTK_STACK(self.pointer),
                                                   name.borrow_to_glib().0,
@@ -86,7 +86,7 @@ impl Stack {
         }
     }
 
-    pub fn set_homogeneous(&mut self, homogeneous: bool) {
+    pub fn set_homogeneous(&self, homogeneous: bool) {
         unsafe {
             ffi::gtk_stack_set_homogeneous(GTK_STACK(self.pointer), to_gboolean(homogeneous))
         }
@@ -98,7 +98,7 @@ impl Stack {
         }
     }
 
-    pub fn set_transition_duration(&mut self, duration: u32) {
+    pub fn set_transition_duration(&self, duration: u32) {
         unsafe {
             ffi::gtk_stack_set_transition_duration(GTK_STACK(self.pointer), duration)
         }
@@ -110,7 +110,7 @@ impl Stack {
         }
     }
 
-    pub fn set_transition_type(&mut self, transition: ::StackTransitionType) {
+    pub fn set_transition_type(&self, transition: ::StackTransitionType) {
         unsafe {
             ffi::gtk_stack_set_transition_type(GTK_STACK(self.pointer), transition)
         }

--- a/src/widgets/stack_switcher.rs
+++ b/src/widgets/stack_switcher.rs
@@ -28,7 +28,7 @@ impl StackSwitcher {
         check_pointer!(tmp_pointer, StackSwitcher)
     }
 
-    pub fn set_stack(&mut self, stack: ::Stack) {
+    pub fn set_stack(&self, stack: ::Stack) {
         unsafe {
             ffi::gtk_stack_switcher_set_stack(GTK_STACK_SWITCHER(self.pointer),
                                               GTK_STACK(stack.unwrap_widget()))

--- a/src/widgets/status_bar.rs
+++ b/src/widgets/status_bar.rs
@@ -29,7 +29,7 @@ impl StatusBar {
         check_pointer!(tmp_pointer, StatusBar)
     }
 
-    pub fn push(&mut self, context_id: u32, text: &str) -> u32 {
+    pub fn push(&self, context_id: u32, text: &str) -> u32 {
         unsafe {
             ffi::gtk_statusbar_push(GTK_STATUSBAR(self.pointer),
                                     context_id,
@@ -37,19 +37,19 @@ impl StatusBar {
         }
     }
 
-    pub fn pop(&mut self, context_id: u32) {
+    pub fn pop(&self, context_id: u32) {
         unsafe {
             ffi::gtk_statusbar_pop(GTK_STATUSBAR(self.pointer), context_id)
         }
     }
 
-    pub fn remove(&mut self, context_id: u32, message_id: u32) {
+    pub fn remove(&self, context_id: u32, message_id: u32) {
         unsafe {
             ffi::gtk_statusbar_remove(GTK_STATUSBAR(self.pointer), context_id, message_id)
         }
     }
 
-    pub fn remove_all(&mut self, context_id: u32) {
+    pub fn remove_all(&self, context_id: u32) {
         unsafe {
             ffi::gtk_statusbar_remove_all(GTK_STATUSBAR(self.pointer), context_id)
         }

--- a/src/widgets/switch.rs
+++ b/src/widgets/switch.rs
@@ -32,7 +32,7 @@ impl Switch {
         check_pointer!(tmp_pointer, Switch)
     }
 
-    pub fn set_active(&mut self, is_active: bool) -> () {
+    pub fn set_active(&self, is_active: bool) -> () {
         unsafe { ffi::gtk_switch_set_active(GTK_SWITCH(self.pointer), to_gboolean(is_active)); }
     }
 

--- a/src/widgets/text_view.rs
+++ b/src/widgets/text_view.rs
@@ -36,7 +36,7 @@ impl TextView {
         check_pointer!(tmp_pointer, TextView)
     }
 
-    pub fn set_buffer(&mut self, buffer: TextBuffer) -> () {
+    pub fn set_buffer(&self, buffer: TextBuffer) -> () {
         unsafe {
             ffi::gtk_text_view_set_buffer(GTK_TEXT_VIEW(self.unwrap_widget()), GTK_TEXT_BUFFER(buffer.unwrap_widget()));
         }

--- a/src/widgets/tool_bar.rs
+++ b/src/widgets/tool_bar.rs
@@ -38,7 +38,7 @@ impl Toolbar {
         check_pointer!(tmp_pointer, Toolbar)
     }
 
-    pub fn insert<T: ::ToolItemTrait>(&mut self,
+    pub fn insert<T: ::ToolItemTrait>(&self,
                                   item: &T,
                                   pos: i32) -> () {
         unsafe {
@@ -46,7 +46,7 @@ impl Toolbar {
         }
     }
 
-    pub fn item_index<T: ::ToolItemTrait>(&mut self, item: &T) -> i32 {
+    pub fn item_index<T: ::ToolItemTrait>(&self, item: &T) -> i32 {
         unsafe {
             ffi::gtk_toolbar_get_item_index(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.unwrap_widget())) as i32
         }
@@ -75,17 +75,17 @@ impl Toolbar {
         }
     }
 
-    pub fn set_drop_highlight_item<T: ::ToolItemTrait>(&mut self, item: &T, index: i32) -> () {
+    pub fn set_drop_highlight_item<T: ::ToolItemTrait>(&self, item: &T, index: i32) -> () {
         unsafe {
             ffi::gtk_toolbar_set_drop_highlight_item(GTK_TOOLBAR(self.pointer), GTK_TOOLITEM(item.unwrap_widget()), index as c_int);
         }
     }
 
-    pub fn set_show_arrow(&mut self, show_arrow: bool) -> () {
+    pub fn set_show_arrow(&self, show_arrow: bool) -> () {
         unsafe { ffi::gtk_toolbar_set_show_arrow(GTK_TOOLBAR(self.pointer), to_gboolean(show_arrow)); }
     }
 
-    pub fn unset_icon_size(&mut self) -> () {
+    pub fn unset_icon_size(&self) -> () {
         unsafe {
             ffi::gtk_toolbar_unset_icon_size(GTK_TOOLBAR(self.pointer))
         }
@@ -113,19 +113,19 @@ impl Toolbar {
         }
     }
 
-    pub fn set_style(&mut self, style: ToolbarStyle) -> () {
+    pub fn set_style(&self, style: ToolbarStyle) -> () {
         unsafe {
             ffi::gtk_toolbar_set_style(GTK_TOOLBAR(self.pointer), style);
         }
     }
 
-    pub fn set_icon_size(&mut self, icon_size: IconSize) -> () {
+    pub fn set_icon_size(&self, icon_size: IconSize) -> () {
         unsafe {
             ffi::gtk_toolbar_set_icon_size(GTK_TOOLBAR(self.pointer), icon_size);
         }
     }
 
-    pub fn unset_style(&mut self) -> () {
+    pub fn unset_style(&self) -> () {
         unsafe {
             ffi::gtk_toolbar_unset_style(GTK_TOOLBAR(self.pointer));
         }

--- a/src/widgets/tree_selection.rs
+++ b/src/widgets/tree_selection.rs
@@ -32,7 +32,7 @@ impl TreeSelection {
         unsafe { ffi::gtk_tree_selection_get_mode(self.pointer) }
     }
 
-    pub fn get_user_data<'r, T>(&mut self) -> &'r mut T {
+    pub fn get_user_data<'r, T>(&self) -> &'r mut T {
         unsafe { ::std::mem::transmute(ffi::gtk_tree_selection_get_user_data(self.pointer)) }
     }
 

--- a/src/widgets/tree_view.rs
+++ b/src/widgets/tree_view.rs
@@ -41,14 +41,14 @@ impl TreeView {
         }
     }
 
-    pub fn set_headers_visible(&mut self, visible: bool) {
+    pub fn set_headers_visible(&self, visible: bool) {
         unsafe {
             ffi::gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(self.pointer),
                                                    to_gboolean(visible))
         }
     }
 
-    pub fn columns_autosize(&mut self) {
+    pub fn columns_autosize(&self) {
         unsafe {
             ffi::gtk_tree_view_columns_autosize(GTK_TREE_VIEW(self.pointer))
         }
@@ -60,7 +60,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_headers_clickable(&mut self, setting: bool) {
+    pub fn set_headers_clickable(&self, setting: bool) {
         unsafe {
             ffi::gtk_tree_view_set_headers_clickable(GTK_TREE_VIEW(self.pointer),
                                                      to_gboolean(setting))
@@ -73,7 +73,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_rules_hint(&mut self, setting: bool) {
+    pub fn set_rules_hint(&self, setting: bool) {
         unsafe {
             ffi::gtk_tree_view_set_rules_hint(GTK_TREE_VIEW(self.pointer),
                                               to_gboolean(setting))
@@ -88,7 +88,7 @@ impl TreeView {
     }
 
     #[cfg(feature = "gtk_3_8")]
-    pub fn set_activate_on_single_click(&mut self, setting: bool) {
+    pub fn set_activate_on_single_click(&self, setting: bool) {
         unsafe {
             ffi::gtk_tree_view_set_activate_on_single_click(GTK_TREE_VIEW(self.pointer),
                                                             to_gboolean(setting))
@@ -101,19 +101,19 @@ impl TreeView {
         }
     }
 
-    pub fn scroll_to_point(&mut self, tree_x: i32, tree_y: i32) {
+    pub fn scroll_to_point(&self, tree_x: i32, tree_y: i32) {
         unsafe {
             ffi::gtk_tree_view_scroll_to_point(GTK_TREE_VIEW(self.pointer), tree_x, tree_y)
         }
     }
 
-    pub fn expand_all(&mut self) {
+    pub fn expand_all(&self) {
         unsafe {
             ffi::gtk_tree_view_expand_all(GTK_TREE_VIEW(self.pointer))
         }
     }
 
-    pub fn collapse_all(&mut self) {
+    pub fn collapse_all(&self) {
         unsafe {
             ffi::gtk_tree_view_collapse_all(GTK_TREE_VIEW(self.pointer))
         }
@@ -125,20 +125,20 @@ impl TreeView {
         }
     }
 
-    pub fn set_reorderable(&mut self, reorderable: bool) {
+    pub fn set_reorderable(&self, reorderable: bool) {
         unsafe {
             ffi::gtk_tree_view_set_reorderable(GTK_TREE_VIEW(self.pointer),
                                                to_gboolean(reorderable))
         }
     }
 
-    pub fn unset_rows_drag_source(&mut self) {
+    pub fn unset_rows_drag_source(&self) {
         unsafe {
             ffi::gtk_tree_view_unset_rows_drag_source(GTK_TREE_VIEW(self.pointer))
         }
     }
 
-    pub fn unset_rows_drag_dest(&mut self) {
+    pub fn unset_rows_drag_dest(&self) {
         unsafe {
             ffi::gtk_tree_view_unset_rows_drag_dest(GTK_TREE_VIEW(self.pointer))
         }
@@ -150,7 +150,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_enable_search(&mut self, enable_search: bool) {
+    pub fn set_enable_search(&self, enable_search: bool) {
         unsafe {
             ffi::gtk_tree_view_set_enable_search(GTK_TREE_VIEW(self.pointer),
                                                  to_gboolean(enable_search))
@@ -163,7 +163,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_search_column(&mut self, column: i32) {
+    pub fn set_search_column(&self, column: i32) {
         unsafe {
             ffi::gtk_tree_view_set_search_column(GTK_TREE_VIEW(self.pointer), column)
         }
@@ -176,7 +176,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_search_entry(&mut self, entry: &mut ::Entry) {
+    pub fn set_search_entry(&self, entry: &::Entry) {
         unsafe {
             ffi::gtk_tree_view_set_search_entry(GTK_TREE_VIEW(self.pointer),
                                                 entry.unwrap_widget() as *mut ffi::C_GtkEntry)
@@ -249,7 +249,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_fixed_height_mode(&mut self, enable: bool) {
+    pub fn set_fixed_height_mode(&self, enable: bool) {
         unsafe {
             ffi::gtk_tree_view_set_fixed_height_mode(GTK_TREE_VIEW(self.pointer),
                                                      to_gboolean(enable))
@@ -262,7 +262,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_hover_selection(&mut self, hover: bool) {
+    pub fn set_hover_selection(&self, hover: bool) {
         unsafe {
             ffi::gtk_tree_view_set_hover_selection(GTK_TREE_VIEW(self.pointer),
                                                    to_gboolean(hover))
@@ -275,7 +275,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_hover_expand(&mut self, expand: bool) {
+    pub fn set_hover_expand(&self, expand: bool) {
         unsafe {
             ffi::gtk_tree_view_set_hover_expand(GTK_TREE_VIEW(self.pointer),
                                                 to_gboolean(expand))
@@ -288,7 +288,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_rubber_banding(&mut self, enable: bool) {
+    pub fn set_rubber_banding(&self, enable: bool) {
         unsafe {
             ffi::gtk_tree_view_set_rubber_banding(GTK_TREE_VIEW(self.pointer),
                                                   to_gboolean(enable))
@@ -307,7 +307,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_grid_lines(&mut self, grid_lines: ::TreeViewGridLines) {
+    pub fn set_grid_lines(&self, grid_lines: ::TreeViewGridLines) {
         unsafe {
             ffi::gtk_tree_view_set_grid_lines(GTK_TREE_VIEW(self.pointer), grid_lines)
         }
@@ -319,7 +319,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_enable_tree_lines(&mut self, enable: bool) {
+    pub fn set_enable_tree_lines(&self, enable: bool) {
         unsafe {
             ffi::gtk_tree_view_set_enable_tree_lines(GTK_TREE_VIEW(self.pointer),
                                                      to_gboolean(enable))
@@ -332,7 +332,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_show_expanders(&mut self, enable: bool) {
+    pub fn set_show_expanders(&self, enable: bool) {
         unsafe {
             ffi::gtk_tree_view_set_show_expanders(GTK_TREE_VIEW(self.pointer),
                                                   to_gboolean(enable))
@@ -345,7 +345,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_level_indentation(&mut self, indentation: i32) {
+    pub fn set_level_indentation(&self, indentation: i32) {
         unsafe {
             ffi::gtk_tree_view_set_level_indentation(GTK_TREE_VIEW(self.pointer),
                                                      indentation)
@@ -358,7 +358,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_tooltip_column(&mut self, column: i32) {
+    pub fn set_tooltip_column(&self, column: i32) {
         unsafe {
             ffi::gtk_tree_view_set_tooltip_column(GTK_TREE_VIEW(self.pointer),
                                                   column)
@@ -375,7 +375,7 @@ impl TreeView {
         }
     }
 
-    pub fn set_model(&mut self, model: &::TreeModel) {
+    pub fn set_model(&self, model: &::TreeModel) {
         unsafe {
             ffi::gtk_tree_view_set_model(GTK_TREE_VIEW(self.pointer),
                                          model.unwrap_pointer())
@@ -388,7 +388,7 @@ impl TreeView {
         TreeSelection::wrap(tmp_pointer)
     }
 
-    pub fn set_cursor(&mut self, path: &TreePath, focus_column: Option<&TreeViewColumn>, start_editing: bool) {
+    pub fn set_cursor(&self, path: &TreePath, focus_column: Option<&TreeViewColumn>, start_editing: bool) {
         unsafe {
             ffi::gtk_tree_view_set_cursor(GTK_TREE_VIEW(self.pointer),
                                           path.unwrap_pointer(),
@@ -397,19 +397,19 @@ impl TreeView {
         };
     }
 
-    pub fn expand_row(&mut self, path: &TreePath, open_all: bool) -> bool {
+    pub fn expand_row(&self, path: &TreePath, open_all: bool) -> bool {
         unsafe {
             to_bool(ffi::gtk_tree_view_expand_row(GTK_TREE_VIEW(self.pointer), path.unwrap_pointer(), to_gboolean(open_all)))
         }
     }
 
-    pub fn collapse_row(&mut self, path: &TreePath) -> bool {
+    pub fn collapse_row(&self, path: &TreePath) -> bool {
         unsafe {
             to_bool(ffi::gtk_tree_view_collapse_row(GTK_TREE_VIEW(self.pointer), path.unwrap_pointer()))
         }
     }
 
-    pub fn append_column(&mut self, column: &::TreeViewColumn) -> i32 {
+    pub fn append_column(&self, column: &::TreeViewColumn) -> i32 {
         unsafe { ffi::gtk_tree_view_append_column(GTK_TREE_VIEW(self.pointer),
                                                   column.unwrap_pointer()) }
     }

--- a/src/widgets/tree_view_column.rs
+++ b/src/widgets/tree_view_column.rs
@@ -31,13 +31,13 @@ impl TreeViewColumn {
         check_pointer!(tmp_pointer, TreeViewColumn, G_OBJECT_FROM_TREE_VIEW_COLUMN)
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         unsafe {
             ffi::gtk_tree_view_column_clear(self.pointer)
         }
     }
 
-    pub fn set_spacing(&mut self, spacing: i32) {
+    pub fn set_spacing(&self, spacing: i32) {
         unsafe {
             ffi::gtk_tree_view_column_set_spacing(self.pointer, spacing)
         }
@@ -49,7 +49,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_visible(&mut self, visible: bool) {
+    pub fn set_visible(&self, visible: bool) {
         unsafe {
             ffi::gtk_tree_view_column_set_visible(self.pointer, to_gboolean(visible))
         }
@@ -61,7 +61,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_resizable(&mut self, resizable: bool) {
+    pub fn set_resizable(&self, resizable: bool) {
         unsafe {
             ffi::gtk_tree_view_column_set_resizable(self.pointer, to_gboolean(resizable))
         }
@@ -73,7 +73,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_sizing(&mut self, ty: ::TreeViewColumnSizing) {
+    pub fn set_sizing(&self, ty: ::TreeViewColumnSizing) {
         unsafe {
             ffi::gtk_tree_view_column_set_sizing(self.pointer, ty)
         }
@@ -139,7 +139,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_title(&mut self, title: &str) {
+    pub fn set_title(&self, title: &str) {
         unsafe {
             ffi::gtk_tree_view_column_set_title(self.pointer,
                                                 title.borrow_to_glib().0);
@@ -153,7 +153,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_expand(&mut self, expand: bool) {
+    pub fn set_expand(&self, expand: bool) {
         unsafe {
             ffi::gtk_tree_view_column_set_expand(self.pointer, to_gboolean(expand))
         }
@@ -165,7 +165,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_clickable(&mut self, clickable: bool) {
+    pub fn set_clickable(&self, clickable: bool) {
         unsafe {
             ffi::gtk_tree_view_column_set_clickable(self.pointer, to_gboolean(clickable))
         }
@@ -177,7 +177,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_widget<T: ::WidgetTrait>(&mut self, widget: &T) {
+    pub fn set_widget<T: ::WidgetTrait>(&self, widget: &T) {
         unsafe {
             ffi::gtk_tree_view_column_set_widget(self.pointer, widget.unwrap_widget())
         }
@@ -189,7 +189,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_alignment(&mut self, x_align: f32) {
+    pub fn set_alignment(&self, x_align: f32) {
         unsafe {
             ffi::gtk_tree_view_column_set_alignment(self.pointer, x_align)
         }
@@ -201,7 +201,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_reorderable(&mut self, reorderable: bool) {
+    pub fn set_reorderable(&self, reorderable: bool) {
         unsafe {
             ffi::gtk_tree_view_column_set_reorderable(self.pointer, to_gboolean(reorderable))
         }
@@ -219,13 +219,13 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_sort_column_id(&mut self, sort_column_id: i32) {
+    pub fn set_sort_column_id(&self, sort_column_id: i32) {
         unsafe {
             ffi::gtk_tree_view_column_set_sort_column_id(self.pointer, sort_column_id)
         }
     }
 
-    pub fn set_sort_indicator(&mut self, setting: bool) {
+    pub fn set_sort_indicator(&self, setting: bool) {
         unsafe {
             ffi::gtk_tree_view_column_set_sort_indicator(self.pointer, to_gboolean(setting))
         }
@@ -237,7 +237,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn set_sort_order(&mut self, order: ::SortType) {
+    pub fn set_sort_order(&self, order: ::SortType) {
         unsafe {
             ffi::gtk_tree_view_column_set_sort_order(self.pointer, order)
         }
@@ -255,7 +255,7 @@ impl TreeViewColumn {
         }
     }
 
-    pub fn queue_resize(&mut self) {
+    pub fn queue_resize(&self) {
         unsafe {
             ffi::gtk_tree_view_column_queue_resize(self.pointer)
         }

--- a/src/widgets/viewport.rs
+++ b/src/widgets/viewport.rs
@@ -34,7 +34,7 @@ impl Viewport {
         }
     }
 
-    pub fn set_shadow_type(&mut self, ty: ShadowType) {
+    pub fn set_shadow_type(&self, ty: ShadowType) {
         unsafe {
             ffi::gtk_viewport_set_shadow_type(GTK_VIEWPORT(self.pointer), ty)
         }


### PR DESCRIPTION
All of the widget types are wrappers around recounted shared references
and contain no data we would ever mutate. There's no meaningful difference
between a shared (&) and a mutable (&mut) reference to a widget, the latter
doesn't guarantee the uniqueness of the reference it wraps.

We have a practical reason to change this now: a `Fn` closure can't call any
mutating methods on the variables moved into it so the status quo would
artificially limit the usefulness of signal handlers proposed in #33.