### PR TITLE
Axe the legacy signals framework

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,19 +95,6 @@ macro_rules! impl_TraitWidget(
     );
 );
 
-// macro_rules! impl_connect(
-//     ($gtk_struct:ident -> $($signal_name:ident),*) => (
-//         $(impl<'a> ::glib::traits::Connect<::signals::$signal_name<'a>> for $gtk_struct {})*
-
-//     )
-// )
-
-macro_rules! impl_connect(
-    ($gtk_struct:ident -> $($signal_name:ident),*) => (
-        $(impl<'a> ::glib::traits::Connect<'a, ::signals::$signal_name<'a>> for $gtk_struct {})*
-    )
-);
-
 macro_rules! impl_GObjectFunctions(
     ($gtk_struct:ident, $ffi_type:ident) => (
         impl $gtk_struct {
@@ -158,52 +145,4 @@ macro_rules! unwrap_widget(
             None => ::std::ptr::null_mut()
         };
     );
-);
-
-macro_rules! impl_widget_events(
-    ($gtk_struct:ident) => (
-        impl_connect!($gtk_struct -> ButtonPressEvent, ButtonReleaseEvent, CanActivateAccel,
-                                     ChildNotify, CompositedChanged, ConfigureEvent, DamageEvent,
-                                     DeleteEvent, DestroyEvent, DirectionChanged, Draw, EnterNotifyEvent,
-                                     Event, EventAfter, Focus, FocusInEvent, FocusOutEvent, GrabBrokenEvent,
-                                     GrabFocus, GrabNotify, Hide, KeyPressEvent,
-                                     KeyReleaseEvent, KeynavFailed, LeaveNotifyEvent, Map, MapEvent,
-                                     MnemonicActivate, MotionNotifyEvent, MoveFocus,
-                                     PropertyNotifyEvent, ProximityInEvent, ProximityOutEvent,
-                                     QueryTooltip, Realize, ScreenChanged, ScrollEvent,
-                                     Show, SizeAllocate,
-                                     StateFlagsChanged, StyleUpdated,
-                                     TouchEvent, WindowStateEvent);
-
-
-        // not implemented:
-        // DragBegin, DragDataDelete, DragDataGet, DragDataReceived, DragDrop
-        // DragEnd, DragFailed, DragLeave, DragMotion, HierarchyChanged, ParentSet, PopuMenu,
-        // UnRealize, VisibilityNotifyEvent, UnMap, UnMapEvent, StyleSet, StateChanged, SelectionRequestEvent,
-        // SelectionReceived, SelectionClearEvent, SelectionGet, SelectionNotifyEvent,
-    )
-);
-
-macro_rules! impl_tree_view_events(
-    ($gtk_struct:ident) => (
-        impl_connect!($gtk_struct -> ColumnsChanged, CursorChanged, ExpandCollapseCursorRow,
-                                     MoveCursor, RowActivated, RowCollapsed, RowExpanded,
-                                     SelectAll, SelectCursorParent, SelectCursorRow,
-                                     StartInteractiveSearch, TestCollapseRow, TestExpandRow,
-                                     ToggleCursorRow, UnselectAll);
-    )
-);
-
-macro_rules! impl_button_events(
-    ($gtk_struct:ident) => (
-        impl_connect!($gtk_struct -> Activate, Clicked, Enter, Leave, Pressed, Released);
-    )
-);
-
-macro_rules! impl_range_events(
-    ($gtk_struct:ident) => (
-        impl_connect!($gtk_struct -> AdjustBounds, MoveSlider, ValueChanged);
-
-    // ChangeValue
-    )
 );

--- a/src/widgets/_box.rs
+++ b/src/widgets/_box.rs
@@ -30,5 +30,3 @@ impl_TraitWidget!(Box);
 impl ::ContainerTrait for Box {}
 impl ::BoxTrait for Box {}
 impl ::OrientableTrait for Box {}
-
-impl_widget_events!(Box);

--- a/src/widgets/about_dialog.rs
+++ b/src/widgets/about_dialog.rs
@@ -243,5 +243,3 @@ impl ::ContainerTrait for AboutDialog {}
 impl ::BinTrait for AboutDialog {}
 impl ::WindowTrait for AboutDialog {}
 impl ::DialogTrait for AboutDialog {}
-
-impl_widget_events!(AboutDialog);

--- a/src/widgets/action_bar.rs
+++ b/src/widgets/action_bar.rs
@@ -53,5 +53,3 @@ impl_TraitWidget!(ActionBar);
 
 impl ::ContainerTrait for ActionBar {}
 impl ::BinTrait for ActionBar {}
-
-impl_widget_events!(ActionBar);

--- a/src/widgets/alignment.rs
+++ b/src/widgets/alignment.rs
@@ -58,5 +58,3 @@ impl_TraitWidget!(Alignment);
 
 impl ::ContainerTrait for Alignment {}
 impl ::BinTrait for Alignment {}
-
-impl_widget_events!(Alignment);

--- a/src/widgets/app_chooser_dialog.rs
+++ b/src/widgets/app_chooser_dialog.rs
@@ -60,5 +60,3 @@ impl ::BinTrait for AppChooserDialog {}
 impl ::WindowTrait for AppChooserDialog {}
 impl ::DialogTrait for AppChooserDialog {}
 impl ::AppChooserTrait for AppChooserDialog {}
-
-impl_widget_events!(AppChooserDialog);

--- a/src/widgets/app_chooser_widget.rs
+++ b/src/widgets/app_chooser_widget.rs
@@ -88,5 +88,3 @@ impl_TraitWidget!(AppChooserWidget);
 
 impl ::ContainerTrait for AppChooserWidget {}
 impl ::BoxTrait for AppChooserWidget {}
-
-impl_widget_events!(AppChooserWidget);

--- a/src/widgets/arrow.rs
+++ b/src/widgets/arrow.rs
@@ -28,5 +28,3 @@ impl_drop!(Arrow);
 impl_TraitWidget!(Arrow);
 
 impl ::MiscTrait for Arrow {}
-
-impl_widget_events!(Arrow);

--- a/src/widgets/aspect_frame.rs
+++ b/src/widgets/aspect_frame.rs
@@ -41,5 +41,3 @@ impl_TraitWidget!(AspectFrame);
 
 impl ::FrameTrait for AspectFrame {}
 impl ::ContainerTrait for AspectFrame {}
-
-impl_widget_events!(AspectFrame);

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -65,6 +65,3 @@ impl_TraitWidget!(Button);
 impl ::ContainerTrait for Button {}
 impl ::ButtonTrait for Button {}
 impl ::BinTrait for Button {}
-
-impl_widget_events!(Button);
-impl_button_events!(Button);

--- a/src/widgets/button_box.rs
+++ b/src/widgets/button_box.rs
@@ -53,5 +53,3 @@ impl_TraitWidget!(ButtonBox);
 impl ::ContainerTrait for ButtonBox {}
 impl ::BoxTrait for ButtonBox {}
 impl ::OrientableTrait for ButtonBox {}
-
-impl_widget_events!(ButtonBox);

--- a/src/widgets/calendar.rs
+++ b/src/widgets/calendar.rs
@@ -115,5 +115,3 @@ impl Calendar {
 
 impl_drop!(Calendar);
 impl_TraitWidget!(Calendar);
-
-impl_widget_events!(Calendar);

--- a/src/widgets/cell_renderer_text.rs
+++ b/src/widgets/cell_renderer_text.rs
@@ -25,5 +25,3 @@ impl_drop!(CellRendererText);
 impl_TraitWidget!(CellRendererText);
 
 impl ::CellRendererTrait for CellRendererText {}
-
-impl_widget_events!(CellRendererText);

--- a/src/widgets/cell_renderer_toggle.rs
+++ b/src/widgets/cell_renderer_toggle.rs
@@ -49,5 +49,3 @@ impl_drop!(CellRendererToggle);
 impl_TraitWidget!(CellRendererToggle);
 
 impl ::CellRendererTrait for CellRendererToggle {}
-
-impl_widget_events!(CellRendererToggle);

--- a/src/widgets/check_button.rs
+++ b/src/widgets/check_button.rs
@@ -37,5 +37,3 @@ impl_TraitWidget!(CheckButton);
 impl ::ContainerTrait for CheckButton {}
 impl ::ButtonTrait for CheckButton {}
 impl ::ToggleButtonTrait for CheckButton {}
-
-impl_widget_events!(CheckButton);

--- a/src/widgets/check_menu_item.rs
+++ b/src/widgets/check_menu_item.rs
@@ -39,5 +39,3 @@ impl ::ContainerTrait for CheckMenuItem {}
 impl ::BinTrait for CheckMenuItem {}
 impl ::MenuItemTrait for CheckMenuItem {}
 impl ::CheckMenuItemTrait for CheckMenuItem {}
-
-impl_widget_events!(CheckMenuItem);

--- a/src/widgets/color_button.rs
+++ b/src/widgets/color_button.rs
@@ -102,7 +102,3 @@ impl_TraitWidget!(ColorButton);
 
 impl ::ContainerTrait for ColorButton {}
 impl ::ButtonTrait for ColorButton {}
-
-impl_widget_events!(ColorButton);
-impl_button_events!(ColorButton);
-

--- a/src/widgets/color_chooser_dialog.rs
+++ b/src/widgets/color_chooser_dialog.rs
@@ -36,5 +36,3 @@ impl ::BinTrait for ColorChooserDialog {}
 impl ::WindowTrait for ColorChooserDialog {}
 impl ::DialogTrait for ColorChooserDialog {}
 impl ::ColorChooserTrait for ColorChooserDialog {}
-
-impl_widget_events!(ColorChooserDialog);

--- a/src/widgets/color_chooser_widget.rs
+++ b/src/widgets/color_chooser_widget.rs
@@ -26,5 +26,3 @@ impl_TraitWidget!(ColorChooserWidget);
 
 impl ::ContainerTrait for ColorChooserWidget {}
 impl ::BoxTrait for ColorChooserWidget {}
-
-impl_widget_events!(ColorChooserWidget);

--- a/src/widgets/combo_box.rs
+++ b/src/widgets/combo_box.rs
@@ -46,6 +46,3 @@ impl_TraitWidget!(ComboBox);
 impl ::ContainerTrait for ComboBox {}
 impl ::BinTrait for ComboBox {}
 impl ::ComboBoxTrait for ComboBox {}
-
-impl_widget_events!(ComboBox);
-

--- a/src/widgets/combo_box_text.rs
+++ b/src/widgets/combo_box_text.rs
@@ -86,5 +86,3 @@ impl_TraitWidget!(ComboBoxText);
 impl ::ContainerTrait for ComboBoxText {}
 impl ::BinTrait for ComboBoxText {}
 impl ::ComboBoxTrait for ComboBoxText {}
-
-impl_widget_events!(ComboBoxText);

--- a/src/widgets/dialog.rs
+++ b/src/widgets/dialog.rs
@@ -42,5 +42,3 @@ impl ::ContainerTrait for Dialog {}
 impl ::BinTrait for Dialog {}
 impl ::WindowTrait for Dialog {}
 impl ::DialogTrait for Dialog {}
-
-impl_widget_events!(Dialog);

--- a/src/widgets/drawing_area.rs
+++ b/src/widgets/drawing_area.rs
@@ -15,5 +15,3 @@ impl DrawingArea {
 }
 
 impl_TraitWidget!(DrawingArea);
-
-impl_widget_events!(DrawingArea);

--- a/src/widgets/entry.rs
+++ b/src/widgets/entry.rs
@@ -42,5 +42,3 @@ impl_TraitWidget!(Entry);
 
 impl ::EntryTrait for Entry {}
 impl ::EditableTrait for Entry {}
-
-impl_widget_events!(Entry);

--- a/src/widgets/entry_completion.rs
+++ b/src/widgets/entry_completion.rs
@@ -181,5 +181,3 @@ impl_drop!(EntryCompletion);
 impl_TraitWidget!(EntryCompletion);
 
 impl ::CellLayoutTrait for EntryCompletion {}
-
-impl_widget_events!(EntryCompletion);

--- a/src/widgets/event_box.rs
+++ b/src/widgets/event_box.rs
@@ -42,5 +42,3 @@ impl_TraitWidget!(EventBox);
 
 impl ::ContainerTrait for EventBox {}
 impl ::BinTrait for EventBox {}
-
-impl_widget_events!(EventBox);

--- a/src/widgets/expander.rs
+++ b/src/widgets/expander.rs
@@ -114,5 +114,3 @@ impl_TraitWidget!(Expander);
 
 impl ::ContainerTrait for Expander {}
 impl ::BinTrait for Expander {}
-
-impl_widget_events!(Expander);

--- a/src/widgets/file_chooser_dialog.rs
+++ b/src/widgets/file_chooser_dialog.rs
@@ -38,5 +38,3 @@ impl ::BinTrait for FileChooserDialog {}
 impl ::WindowTrait for FileChooserDialog {}
 impl ::DialogTrait for FileChooserDialog {}
 impl ::FileChooserTrait for FileChooserDialog {}
-
-impl_widget_events!(FileChooserDialog);

--- a/src/widgets/file_chooser_widget.rs
+++ b/src/widgets/file_chooser_widget.rs
@@ -26,5 +26,3 @@ impl_TraitWidget!(FileChooserWidget);
 
 impl ::ContainerTrait for FileChooserWidget {}
 impl ::BoxTrait for FileChooserWidget {}
-
-impl_widget_events!(FileChooserWidget);

--- a/src/widgets/fixed.rs
+++ b/src/widgets/fixed.rs
@@ -42,5 +42,3 @@ impl_drop!(Fixed);
 impl_TraitWidget!(Fixed);
 
 impl ::ContainerTrait for Fixed {}
-
-impl_widget_events!(Fixed);

--- a/src/widgets/flow_box.rs
+++ b/src/widgets/flow_box.rs
@@ -169,8 +169,6 @@ impl_TraitWidget!(FlowBox);
 
 impl ::ContainerTrait for FlowBox {}
 
-impl_widget_events!(FlowBox);
-
 struct_Widget!(FlowBoxChild);
 
 impl FlowBoxChild {
@@ -203,5 +201,3 @@ impl_TraitWidget!(FlowBoxChild);
 
 impl ::ContainerTrait for FlowBoxChild {}
 impl ::BinTrait for FlowBoxChild {}
-
-impl_widget_events!(FlowBoxChild);

--- a/src/widgets/font_button.rs
+++ b/src/widgets/font_button.rs
@@ -91,6 +91,3 @@ impl_TraitWidget!(FontButton);
 
 impl ::ContainerTrait for FontButton {}
 impl ::ButtonTrait for FontButton {}
-
-impl_widget_events!(FontButton);
-impl_button_events!(FontButton);

--- a/src/widgets/font_chooser_dialog.rs
+++ b/src/widgets/font_chooser_dialog.rs
@@ -36,5 +36,3 @@ impl ::BinTrait for FontChooserDialog {}
 impl ::WindowTrait for FontChooserDialog {}
 impl ::DialogTrait for FontChooserDialog {}
 impl ::FontChooserTrait for FontChooserDialog {}
-
-impl_widget_events!(FontChooserDialog);

--- a/src/widgets/font_chooser_widget.rs
+++ b/src/widgets/font_chooser_widget.rs
@@ -26,5 +26,3 @@ impl_TraitWidget!(FontChooserWidget);
 
 impl ::ContainerTrait for FontChooserWidget {}
 impl ::BoxTrait for FontChooserWidget {}
-
-impl_widget_events!(FontChooserWidget);

--- a/src/widgets/frame.rs
+++ b/src/widgets/frame.rs
@@ -25,5 +25,3 @@ impl_TraitWidget!(Frame);
 impl ::FrameTrait for Frame {}
 impl ::ContainerTrait for Frame {}
 impl ::BinTrait for Frame {}
-
-impl_widget_events!(Frame);

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -146,5 +146,3 @@ impl_TraitWidget!(Grid);
 
 impl ::ContainerTrait for Grid {}
 impl ::OrientableTrait for Grid {}
-
-impl_widget_events!(Grid);

--- a/src/widgets/header_bar.rs
+++ b/src/widgets/header_bar.rs
@@ -99,5 +99,3 @@ impl_drop!(HeaderBar);
 impl_TraitWidget!(HeaderBar);
 
 impl ::ContainerTrait for HeaderBar {}
-
-impl_widget_events!(HeaderBar);

--- a/src/widgets/icon_view.rs
+++ b/src/widgets/icon_view.rs
@@ -292,5 +292,3 @@ impl_TraitWidget!(IconView);
 
 impl ::ScrollableTrait for IconView {}
 impl ::CellLayoutTrait for IconView {}
-
-impl_widget_events!(IconView);

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -73,5 +73,3 @@ impl_drop!(Image);
 impl_TraitWidget!(Image);
 
 impl ::MiscTrait for Image {}
-
-impl_widget_events!(Image);

--- a/src/widgets/info_bar.rs
+++ b/src/widgets/info_bar.rs
@@ -81,5 +81,3 @@ impl_TraitWidget!(InfoBar);
 impl ::ContainerTrait for InfoBar {}
 impl ::BoxTrait for InfoBar {}
 impl ::OrientableTrait for InfoBar {}
-
-impl_widget_events!(InfoBar);

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -39,5 +39,3 @@ impl_TraitWidget!(Label);
 
 impl ::MiscTrait for Label {}
 impl ::LabelTrait for Label {}
-
-impl_widget_events!(Label);

--- a/src/widgets/layout.rs
+++ b/src/widgets/layout.rs
@@ -58,5 +58,3 @@ impl_TraitWidget!(Layout);
 
 impl ::ContainerTrait for Layout {}
 impl ::ScrollableTrait for Layout {}
-
-impl_widget_events!(Layout);

--- a/src/widgets/level_bar.rs
+++ b/src/widgets/level_bar.rs
@@ -131,5 +131,3 @@ impl_drop!(LevelBar);
 impl_TraitWidget!(LevelBar);
 
 impl ::OrientableTrait for LevelBar {}
-
-impl_widget_events!(LevelBar);

--- a/src/widgets/link_button.rs
+++ b/src/widgets/link_button.rs
@@ -58,6 +58,3 @@ impl_TraitWidget!(LinkButton);
 
 impl ::ContainerTrait for LinkButton {}
 impl ::ButtonTrait for LinkButton {}
-
-impl_widget_events!(LinkButton);
-impl_button_events!(LinkButton);

--- a/src/widgets/list_box.rs
+++ b/src/widgets/list_box.rs
@@ -197,5 +197,3 @@ impl_TraitWidget!(ListBoxRow);
 
 impl ::ContainerTrait for ListBoxRow {}
 impl ::BinTrait for ListBoxRow {}
-
-impl_widget_events!(ListBox);

--- a/src/widgets/lock_button.rs
+++ b/src/widgets/lock_button.rs
@@ -39,6 +39,3 @@ impl_TraitWidget!(LockButton);
 impl ::ContainerTrait for LockButton {}
 impl ::ButtonTrait for LockButton {}
 impl ::ActionableTrait for LockButton {}
-
-impl_widget_events!(LockButton);
-impl_button_events!(LockButton);

--- a/src/widgets/menu_button.rs
+++ b/src/widgets/menu_button.rs
@@ -48,5 +48,3 @@ impl_TraitWidget!(MenuButton);
 impl ::ContainerTrait for MenuButton {}
 impl ::ButtonTrait for MenuButton {}
 impl ::ToggleButtonTrait for MenuButton {}
-
-impl_widget_events!(MenuButton);

--- a/src/widgets/menu_item.rs
+++ b/src/widgets/menu_item.rs
@@ -37,5 +37,3 @@ impl_TraitWidget!(MenuItem);
 impl ::ContainerTrait for MenuItem {}
 impl ::BinTrait for MenuItem {}
 impl ::MenuItemTrait for MenuItem {}
-
-impl_widget_events!(MenuItem);

--- a/src/widgets/menu_tool_button.rs
+++ b/src/widgets/menu_tool_button.rs
@@ -55,5 +55,3 @@ impl ::ContainerTrait for MenuToolButton {}
 impl ::BinTrait for MenuToolButton {}
 impl ::ToolItemTrait for MenuToolButton {}
 impl ::ToolButtonTrait for MenuToolButton {}
-
-impl_widget_events!(MenuToolButton);

--- a/src/widgets/message_dialog.rs
+++ b/src/widgets/message_dialog.rs
@@ -59,5 +59,3 @@ impl ::ContainerTrait for MessageDialog {}
 impl ::BinTrait for MessageDialog {}
 impl ::WindowTrait for MessageDialog {}
 impl ::DialogTrait for MessageDialog {}
-
-impl_widget_events!(MessageDialog);

--- a/src/widgets/note_book.rs
+++ b/src/widgets/note_book.rs
@@ -355,6 +355,3 @@ impl_drop!(NoteBook);
 impl_TraitWidget!(NoteBook);
 
 impl ::ContainerTrait for NoteBook {}
-
-impl_widget_events!(NoteBook);
-

--- a/src/widgets/overlay.rs
+++ b/src/widgets/overlay.rs
@@ -28,5 +28,3 @@ impl_TraitWidget!(Overlay);
 
 impl ::ContainerTrait for Overlay {}
 impl ::BinTrait for Overlay {}
-
-impl_widget_events!(Overlay);

--- a/src/widgets/page_setup_unix_dialog.rs
+++ b/src/widgets/page_setup_unix_dialog.rs
@@ -63,5 +63,3 @@ impl ::ContainerTrait for PageSetupUnixDialog {}
 impl ::BinTrait for PageSetupUnixDialog {}
 impl ::WindowTrait for PageSetupUnixDialog {}
 impl ::DialogTrait for PageSetupUnixDialog {}
-
-impl_widget_events!(PageSetupUnixDialog);

--- a/src/widgets/paned.rs
+++ b/src/widgets/paned.rs
@@ -78,5 +78,3 @@ impl_drop!(Paned);
 impl_TraitWidget!(Paned);
 
 impl ::ContainerTrait for Paned {}
-
-impl_widget_events!(Paned);

--- a/src/widgets/paper_size.rs
+++ b/src/widgets/paper_size.rs
@@ -167,5 +167,3 @@ impl Clone for PaperSize {
 }
 
 impl_TraitWidget!(PaperSize);
-
-impl_widget_events!(PaperSize);

--- a/src/widgets/places_sidebar.rs
+++ b/src/widgets/places_sidebar.rs
@@ -66,5 +66,3 @@ impl_TraitWidget!(PlacesSidebar);
 impl ::ContainerTrait for PlacesSidebar {}
 impl ::BinTrait for PlacesSidebar {}
 impl ::ScrolledWindowTrait for PlacesSidebar {}
-
-impl_widget_events!(PlacesSidebar);

--- a/src/widgets/popover.rs
+++ b/src/widgets/popover.rs
@@ -53,5 +53,3 @@ impl_TraitWidget!(Popover);
 
 impl ::ContainerTrait for Popover {}
 impl ::BinTrait for Popover {}
-
-impl_widget_events!(Popover);

--- a/src/widgets/print_settings.rs
+++ b/src/widgets/print_settings.rs
@@ -334,5 +334,3 @@ impl PrintSettings {
 
 impl_drop!(PrintSettings);
 impl_TraitWidget!(PrintSettings);
-
-impl_widget_events!(PrintSettings);

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -84,5 +84,3 @@ impl_drop!(ProgressBar);
 impl_TraitWidget!(ProgressBar);
 
 impl ::OrientableTrait for ProgressBar {}
-
-impl_widget_events!(ProgressBar);

--- a/src/widgets/radio_button.rs
+++ b/src/widgets/radio_button.rs
@@ -50,5 +50,3 @@ impl ::ContainerTrait for RadioButton {}
 impl ::ButtonTrait for RadioButton {}
 impl ::BinTrait for RadioButton {}
 impl ::ToggleButtonTrait for RadioButton {}
-
-impl_widget_events!(RadioButton);

--- a/src/widgets/recent_chooser_dialog.rs
+++ b/src/widgets/recent_chooser_dialog.rs
@@ -54,5 +54,3 @@ impl ::BinTrait for RecentChooserDialog {}
 impl ::WindowTrait for RecentChooserDialog {}
 impl ::DialogTrait for RecentChooserDialog {}
 impl ::RecentChooserTrait for RecentChooserDialog {}
-
-impl_widget_events!(RecentChooserDialog);

--- a/src/widgets/recent_chooser_widget.rs
+++ b/src/widgets/recent_chooser_widget.rs
@@ -30,5 +30,3 @@ impl ::ContainerTrait for RecentChooserWidget {}
 impl ::OrientableTrait for RecentChooserWidget {}
 impl ::RecentChooserTrait for RecentChooserWidget {}
 impl ::BoxTrait for RecentChooserWidget {}
-
-impl_widget_events!(RecentChooserWidget);

--- a/src/widgets/recent_info.rs
+++ b/src/widgets/recent_info.rs
@@ -169,5 +169,3 @@ impl RecentInfo {
 
 impl_drop!(RecentInfo);
 impl_TraitWidget!(RecentInfo);
-
-impl_widget_events!(RecentInfo);

--- a/src/widgets/recent_manager.rs
+++ b/src/widgets/recent_manager.rs
@@ -79,5 +79,3 @@ impl RecentManager {
 
 impl_drop!(RecentManager);
 impl_TraitWidget!(RecentManager);
-
-impl_widget_events!(RecentManager);

--- a/src/widgets/revealer.rs
+++ b/src/widgets/revealer.rs
@@ -66,5 +66,3 @@ impl_TraitWidget!(Revealer);
 
 impl ::ContainerTrait for Revealer {}
 impl ::BinTrait for Revealer {}
-
-impl_widget_events!(Revealer);

--- a/src/widgets/scale.rs
+++ b/src/widgets/scale.rs
@@ -102,6 +102,3 @@ impl_TraitWidget!(Scale);
 
 impl ::OrientableTrait for Scale {}
 impl ::RangeTrait for Scale {}
-
-impl_widget_events!(Scale);
-impl_range_events!(Scale);

--- a/src/widgets/scale_button.rs
+++ b/src/widgets/scale_button.rs
@@ -34,6 +34,3 @@ impl ::ContainerTrait for ScaleButton {}
 impl ::ButtonTrait for ScaleButton {}
 impl ::ScaleButtonTrait for ScaleButton {}
 impl ::OrientableTrait for ScaleButton {}
-
-impl_widget_events!(ScaleButton);
-impl_button_events!(ScaleButton);

--- a/src/widgets/scrollbar.rs
+++ b/src/widgets/scrollbar.rs
@@ -21,6 +21,3 @@ impl_TraitWidget!(ScrollBar);
 
 impl ::RangeTrait for ScrollBar {}
 impl ::OrientableTrait for ScrollBar {}
-
-impl_widget_events!(ScrollBar);
-impl_range_events!(ScrollBar);

--- a/src/widgets/scrolled_window.rs
+++ b/src/widgets/scrolled_window.rs
@@ -45,5 +45,3 @@ impl_TraitWidget!(ScrolledWindow);
 
 impl ::ScrolledWindowTrait for ScrolledWindow {}
 impl ::ContainerTrait for ScrolledWindow {}
-
-impl_widget_events!(ScrolledWindow);

--- a/src/widgets/search_bar.rs
+++ b/src/widgets/search_bar.rs
@@ -46,5 +46,3 @@ impl_TraitWidget!(SearchBar);
 
 impl ::ContainerTrait for SearchBar {}
 impl ::BinTrait for SearchBar {}
-
-impl_widget_events!(SearchBar);

--- a/src/widgets/search_entry.rs
+++ b/src/widgets/search_entry.rs
@@ -25,5 +25,3 @@ impl_TraitWidget!(SearchEntry);
 
 impl ::EntryTrait for SearchEntry {}
 impl ::EditableTrait for SearchEntry {}
-
-impl_widget_events!(SearchEntry);

--- a/src/widgets/separator.rs
+++ b/src/widgets/separator.rs
@@ -21,5 +21,3 @@ impl_drop!(Separator);
 impl_TraitWidget!(Separator);
 
 impl ::OrientableTrait for Separator {}
-
-impl_widget_events!(Separator);

--- a/src/widgets/separator_menu_item.rs
+++ b/src/widgets/separator_menu_item.rs
@@ -22,5 +22,3 @@ impl_TraitWidget!(SeparatorMenuItem);
 impl ::ContainerTrait for SeparatorMenuItem {}
 impl ::BinTrait for SeparatorMenuItem {}
 impl ::MenuItemTrait for SeparatorMenuItem {}
-
-impl_widget_events!(SeparatorMenuItem);

--- a/src/widgets/separator_tool_item.rs
+++ b/src/widgets/separator_tool_item.rs
@@ -32,5 +32,3 @@ impl_TraitWidget!(SeparatorToolItem);
 impl ::ContainerTrait for SeparatorToolItem {}
 impl ::BinTrait for SeparatorToolItem {}
 impl ::ToolItemTrait for SeparatorToolItem {}
-
-impl_widget_events!(SeparatorToolItem);

--- a/src/widgets/socket.rs
+++ b/src/widgets/socket.rs
@@ -36,5 +36,3 @@ impl_drop!(Socket);
 impl_TraitWidget!(Socket);
 
 impl ::ContainerTrait for Socket {}
-
-impl_widget_events!(Socket);

--- a/src/widgets/spin_button.rs
+++ b/src/widgets/spin_button.rs
@@ -172,6 +172,3 @@ impl_TraitWidget!(SpinButton);
 impl ::EntryTrait for SpinButton {}
 impl ::EditableTrait for SpinButton {}
 impl ::OrientableTrait for SpinButton {}
-
-impl_widget_events!(SpinButton);
-impl_connect!(SpinButton -> ChangedValue, ValueChanged, Wrapped); // Input, Output

--- a/src/widgets/spinner.rs
+++ b/src/widgets/spinner.rs
@@ -32,5 +32,3 @@ impl Spinner {
 
 impl_drop!(Spinner);
 impl_TraitWidget!(Spinner);
-
-impl_widget_events!(Spinner);

--- a/src/widgets/stack.rs
+++ b/src/widgets/stack.rs
@@ -116,5 +116,3 @@ impl_drop!(Stack);
 impl_TraitWidget!(Stack);
 
 impl ::ContainerTrait for Stack {}
-
-impl_widget_events!(Stack);

--- a/src/widgets/stack_switcher.rs
+++ b/src/widgets/stack_switcher.rs
@@ -39,5 +39,3 @@ impl_TraitWidget!(StackSwitcher);
 
 impl ::ContainerTrait for StackSwitcher {}
 impl ::BoxTrait for StackSwitcher {}
-
-impl_widget_events!(StackSwitcher);

--- a/src/widgets/status_bar.rs
+++ b/src/widgets/status_bar.rs
@@ -57,5 +57,3 @@ impl_TraitWidget!(StatusBar);
 impl ::ContainerTrait for StatusBar {}
 impl ::BoxTrait for StatusBar {}
 impl ::OrientableTrait for StatusBar {}
-
-impl_widget_events!(StatusBar);

--- a/src/widgets/switch.rs
+++ b/src/widgets/switch.rs
@@ -32,5 +32,3 @@ impl Switch {
 
 impl_drop!(Switch);
 impl_TraitWidget!(Switch);
-
-impl_widget_events!(Switch);

--- a/src/widgets/text_buffer.rs
+++ b/src/widgets/text_buffer.rs
@@ -28,5 +28,3 @@ impl_drop!(TextBuffer);
 impl_TraitWidget!(TextBuffer);
 
 impl ::TextBufferTrait for TextBuffer {}
-
-impl_widget_events!(TextBuffer);

--- a/src/widgets/text_view.rs
+++ b/src/widgets/text_view.rs
@@ -263,5 +263,3 @@ impl_drop!(TextView);
 impl_TraitWidget!(TextView);
 
 impl ::ScrollableTrait for TextView {}
-
-impl_widget_events!(TextView);

--- a/src/widgets/toggle_button.rs
+++ b/src/widgets/toggle_button.rs
@@ -42,6 +42,3 @@ impl_TraitWidget!(ToggleButton);
 impl ::ContainerTrait for ToggleButton {}
 impl ::ButtonTrait for ToggleButton {}
 impl ::ToggleButtonTrait for ToggleButton {}
-
-impl_widget_events!(ToggleButton);
-impl_button_events!(ToggleButton);

--- a/src/widgets/toggle_tool_button.rs
+++ b/src/widgets/toggle_tool_button.rs
@@ -30,5 +30,3 @@ impl ::BinTrait for ToggleToolButton {}
 impl ::ToolItemTrait for ToggleToolButton {}
 impl ::ToolButtonTrait for ToggleToolButton {}
 impl ::ToggleToolButtonTrait for ToggleToolButton {}
-
-impl_widget_events!(ToggleToolButton);

--- a/src/widgets/tool_bar.rs
+++ b/src/widgets/tool_bar.rs
@@ -127,5 +127,3 @@ impl_TraitWidget!(Toolbar);
 impl ::ContainerTrait for Toolbar {}
 impl ::ToolShellTrait for Toolbar {}
 impl ::OrientableTrait for Toolbar {}
-
-impl_widget_events!(Toolbar);

--- a/src/widgets/tool_button.rs
+++ b/src/widgets/tool_button.rs
@@ -39,6 +39,3 @@ impl ::ContainerTrait for ToolButton {}
 impl ::BinTrait for ToolButton {}
 impl ::ToolItemTrait for ToolButton {}
 impl ::ToolButtonTrait for ToolButton {}
-
-impl_widget_events!(ToolButton);
-impl_button_events!(ToolButton);

--- a/src/widgets/tool_item.rs
+++ b/src/widgets/tool_item.rs
@@ -22,5 +22,3 @@ impl_TraitWidget!(ToolItem);
 impl ::ContainerTrait for ToolItem {}
 impl ::BinTrait for ToolItem {}
 impl ::ToolItemTrait for ToolItem {}
-
-impl_widget_events!(ToolItem);

--- a/src/widgets/tool_item_group.rs
+++ b/src/widgets/tool_item_group.rs
@@ -109,5 +109,3 @@ impl_TraitWidget!(ToolItemGroup);
 
 impl ::ContainerTrait for ToolItemGroup {}
 impl ::BinTrait for ToolItemGroup {}
-
-impl_widget_events!(ToolItemGroup);

--- a/src/widgets/tool_palette.rs
+++ b/src/widgets/tool_palette.rs
@@ -103,5 +103,3 @@ impl_drop!(ToolPalette);
 impl_TraitWidget!(ToolPalette);
 
 impl ::ContainerTrait for ToolPalette {}
-
-impl_widget_events!(ToolPalette);

--- a/src/widgets/tree_selection.rs
+++ b/src/widgets/tree_selection.rs
@@ -114,6 +114,4 @@ impl glib::traits::FFIGObject for TreeSelection {
     }
 }
 
-impl_connect!(TreeSelection -> Changed);
-
 impl_drop!(TreeSelection, GTK_TREE_SELECTION);

--- a/src/widgets/tree_view.rs
+++ b/src/widgets/tree_view.rs
@@ -409,6 +409,3 @@ impl_TraitWidget!(TreeView);
 
 impl ::ContainerTrait for TreeView {}
 impl ::ScrollableTrait for TreeView {}
-
-impl_widget_events!(TreeView);
-impl_tree_view_events!(TreeView);

--- a/src/widgets/tree_view_column.rs
+++ b/src/widgets/tree_view_column.rs
@@ -316,8 +316,6 @@ impl glib::traits::FFIGObject for TreeViewColumn {
     }
 }
 
-impl_connect!(TreeViewColumn -> Clicked);
-
 impl Drop for TreeViewColumn {
     fn drop(&mut self) {
         unsafe {

--- a/src/widgets/viewport.rs
+++ b/src/widgets/viewport.rs
@@ -36,5 +36,3 @@ impl_TraitWidget!(Viewport);
 impl ::ContainerTrait for Viewport {}
 impl ::BinTrait for Viewport {}
 impl ::ScrollableTrait for Viewport {}
-
-impl_widget_events!(Viewport);

--- a/src/widgets/volume_button.rs
+++ b/src/widgets/volume_button.rs
@@ -23,5 +23,3 @@ impl ::ContainerTrait for VolumeButton {}
 impl ::ButtonTrait for VolumeButton {}
 impl ::ScaleButtonTrait for VolumeButton {}
 impl ::OrientableTrait for VolumeButton {}
-
-impl_widget_events!(VolumeButton);

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -31,5 +31,3 @@ impl_TraitWidget!(Window);
 impl ::ContainerTrait for Window {}
 impl ::WindowTrait for Window {}
 impl ::BinTrait for Window {}
-
-impl_widget_events!(Window);


### PR DESCRIPTION
This is a big [breaking-change].
The new way of using signals is demonstrated in the examples repo.
The new traits for assigning signal handlers are defined in signal.rs.
The crate doesn't take ages to compile any more, yay!