### PR TITLE
Update dialog parent parameters to borrow window

### DIFF
--- a/src/widgets/app_chooser_dialog.rs
+++ b/src/widgets/app_chooser_dialog.rs
@@ -10,7 +10,7 @@ use glib::translate::{FromGlibPtr, ToGlibPtr};
 struct_Widget!(AppChooserDialog);
 
 impl AppChooserDialog {
-    pub fn new_for_content_type(parent: Option<::Window>, flags: ::DialogFlags, content_type: &str) -> Option<AppChooserDialog> {
+    pub fn new_for_content_type(parent: Option<&::Window>, flags: ::DialogFlags, content_type: &str) -> Option<AppChooserDialog> {
         let tmp_pointer = unsafe {
             let parent = match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),

--- a/src/widgets/color_chooser_dialog.rs
+++ b/src/widgets/color_chooser_dialog.rs
@@ -10,7 +10,7 @@ use glib::translate::ToGlibPtr;
 struct_Widget!(ColorChooserDialog);
 
 impl ColorChooserDialog {
-    pub fn new(title: &str, parent: Option<::Window>) -> Option<ColorChooserDialog> {
+    pub fn new(title: &str, parent: Option<&::Window>) -> Option<ColorChooserDialog> {
         let tmp_pointer = unsafe {
             ffi::gtk_color_chooser_dialog_new(title.borrow_to_glib().0,
                 match parent {

--- a/src/widgets/dialog.rs
+++ b/src/widgets/dialog.rs
@@ -19,7 +19,7 @@ impl Dialog {
         }
     }
 
-    pub fn with_buttons<T: DialogButtons>(title: &str, parent: Option<::Window>,
+    pub fn with_buttons<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                           flags: ::DialogFlags, buttons: T) -> Dialog {
         unsafe {
             let parent = match parent {

--- a/src/widgets/file_chooser_dialog.rs
+++ b/src/widgets/file_chooser_dialog.rs
@@ -11,7 +11,7 @@ use DialogButtons;
 struct_Widget!(FileChooserDialog);
 
 impl FileChooserDialog {
-    pub fn new<T: DialogButtons>(title: &str, parent: Option<::Window>,
+    pub fn new<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                  action: ::FileChooserAction, buttons: T) -> FileChooserDialog {
         unsafe {
             let parent = match parent {

--- a/src/widgets/font_chooser_dialog.rs
+++ b/src/widgets/font_chooser_dialog.rs
@@ -10,7 +10,7 @@ use glib::translate::ToGlibPtr;
 struct_Widget!(FontChooserDialog);
 
 impl FontChooserDialog {
-    pub fn new(title: &str, parent: Option<::Window>) -> Option<FontChooserDialog> {
+    pub fn new(title: &str, parent: Option<&::Window>) -> Option<FontChooserDialog> {
         let tmp = unsafe {
             ffi::gtk_font_chooser_dialog_new(title.borrow_to_glib().0,
                 match parent {

--- a/src/widgets/message_dialog.rs
+++ b/src/widgets/message_dialog.rs
@@ -10,7 +10,7 @@ use glib::translate::ToGlibPtr;
 struct_Widget!(MessageDialog);
 
 impl MessageDialog {
-    pub fn new(parent: Option<::Window>, flags: ::DialogFlags, _type: ::MessageType, buttons: ::ButtonsType) -> Option<MessageDialog> {
+    pub fn new(parent: Option<&::Window>, flags: ::DialogFlags, _type: ::MessageType, buttons: ::ButtonsType) -> Option<MessageDialog> {
         let tmp_pointer = unsafe { ffi::gtk_message_dialog_new(match parent {
                 Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
                 None => ::std::ptr::null_mut()
@@ -24,7 +24,7 @@ impl MessageDialog {
         }
     }
 
-    pub fn new_with_markup(parent: Option<::Window>, flags: ::DialogFlags, _type: ::MessageType, buttons: ::ButtonsType, markup: &str) -> Option<MessageDialog> {
+    pub fn new_with_markup(parent: Option<&::Window>, flags: ::DialogFlags, _type: ::MessageType, buttons: ::ButtonsType, markup: &str) -> Option<MessageDialog> {
         //gtk_message_dialog_new_with_markup
         match MessageDialog::new(parent, flags, _type, buttons) {
             Some(m) => {

--- a/src/widgets/page_setup_unix_dialog.rs
+++ b/src/widgets/page_setup_unix_dialog.rs
@@ -10,7 +10,7 @@ use std::str;
 struct_Widget!(PageSetupUnixDialog);
 
 impl PageSetupUnixDialog {
-    pub fn new(title: &str, parent: Option<::Window>) -> Option<PageSetupUnixDialog> {
+    pub fn new(title: &str, parent: Option<&::Window>) -> Option<PageSetupUnixDialog> {
         let tmp_pointer = unsafe {
             title.with_c_str(|c_str|{
                 ffi::gtk_page_setup_unix_dialog_new(match parent {

--- a/src/widgets/recent_chooser_dialog.rs
+++ b/src/widgets/recent_chooser_dialog.rs
@@ -12,7 +12,7 @@ use cast::{GTK_WINDOW, GTK_RECENT_MANAGER};
 struct_Widget!(RecentChooserDialog);
 
 impl RecentChooserDialog {
-    pub fn new<T: DialogButtons>(title: &str, parent: Option<::Window>,
+    pub fn new<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                  buttons: T) -> RecentChooserDialog {
         let parent = match parent {
             Some(ref p) => GTK_WINDOW(p.unwrap_widget()),
@@ -28,7 +28,7 @@ impl RecentChooserDialog {
         }
     }
 
-    pub fn new_for_manager<T: DialogButtons>(title: &str, parent: Option<::Window>,
+    pub fn new_for_manager<T: DialogButtons>(title: &str, parent: Option<&::Window>,
                                              manager: &::RecentManager, buttons: T) -> RecentChooserDialog {
         let parent = match parent {
             Some(ref p) => GTK_WINDOW(p.unwrap_widget()),


### PR DESCRIPTION
Neither do we require ownership of the parent window, nor are dialog creators usually in a position to give it up.