### PR TITLE
Added gtk::init_check()

### DIFF
--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -335,6 +335,7 @@ extern "C" {
     // Gtk Main Loop + events
     //=========================================================================
     pub fn gtk_init                            (argc: *const c_int, argv: *const *const *const c_char) -> ();
+    pub fn gtk_init_check                      (argc: *const c_int, argv: *const *const *const c_char) -> gboolean;
     pub fn gtk_main                            () -> ();
     pub fn gtk_main_quit                       () -> ();
     pub fn gtk_main_level                      () -> c_uint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub use glib::ValuePublic;
 // These are/should be inlined
 pub use self::rt::{
     init,
+    init_check,
     main,
     main_quit,
     main_level,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ pub use glib::ValuePublic;
 // These are/should be inlined
 pub use self::rt::{
     init,
-    init_check,
     main,
     main_quit,
     main_level,

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -8,6 +8,9 @@ use ffi;
 use glib::translate::{from_glib_none};
 use glib::{to_bool, to_gboolean};
 
+/// Call this function before using any other GTK+ functions.
+/// Note that this function calls gtk_init_check() rather than gtk_init(),
+/// so will not cause the program to terminate if GTK could not be initialized.
 pub fn init() -> Result<(), ()> {
     unsafe {
 	match to_bool(ffi::gtk_init_check(ptr::null(), ptr::null())) {

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -14,6 +14,10 @@ pub fn init() {
     }
 }
 
+pub fn init_check() -> bool {
+    unsafe { to_bool(ffi::gtk_init_check(ptr::null(), ptr::null())) }
+}
+
 pub fn main() {
     unsafe {
         ffi::gtk_main();

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -8,14 +8,13 @@ use ffi;
 use glib::translate::{from_glib_none};
 use glib::{to_bool, to_gboolean};
 
-pub fn init() {
+pub fn init() -> Result<(), ()> {
     unsafe {
-        ffi::gtk_init(ptr::null(), ptr::null());
+	match to_bool(ffi::gtk_init_check(ptr::null(), ptr::null())) {
+	    true => Ok(()),
+	    false => Err(())
+	}
     }
-}
-
-pub fn init_check() -> bool {
-    unsafe { to_bool(ffi::gtk_init_check(ptr::null(), ptr::null())) }
 }
 
 pub fn main() {

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -9,8 +9,11 @@ use glib::translate::{from_glib_none};
 use glib::{to_bool, to_gboolean};
 
 /// Call this function before using any other GTK+ functions.
+///
 /// Note that this function calls gtk_init_check() rather than gtk_init(),
 /// so will not cause the program to terminate if GTK could not be initialized.
+/// Instead, an Ok is returned if the windowing system was successfully
+/// initialized otherwise an Err is returned.
 pub fn init() -> Result<(), ()> {
     unsafe {
 	match to_bool(ffi::gtk_init_check(ptr::null(), ptr::null())) {


### PR DESCRIPTION
A small change to make gtk_init_check() available through gtk::init_check() - returning a bool to report whether GTK has been initialised successfully.