### PR TITLE
Added move_, set_type_hint, and get_window methods

### DIFF
--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -353,6 +353,8 @@ extern "C" {
     pub fn gtk_window_set_position             (window: *mut GtkWindow, position: enums::WindowPosition) -> ();
     pub fn gtk_window_set_decorated            (window: *mut GtkWindow, setting: gboolean) -> ();
     pub fn gtk_window_set_titlebar             (window: *mut GtkWindow, titlebar: *mut GtkWidget) -> ();
+    pub fn gtk_window_set_type_hint            (window: *mut GtkWindow, hint: gdk_ffi::enums::WindowTypeHint);
+    pub fn gtk_window_move                     (window: *mut GtkWindow, x: c_int, y: c_int);
 
     // pub fn gtk_window_set_role(window: *const const GtkWindow, role: *const c_char) -> ();
     // pub fn gtk_window_set_startup_id(window: *const const GtkWindow, startup_id: *const c_char) -> ();
@@ -509,7 +511,7 @@ extern "C" {
     pub fn gtk_widget_get_has_tooltip          (widget: *mut GtkWidget) -> gboolean;
     pub fn gtk_widget_set_has_tooltip          (widget: *mut GtkWidget, has_tooltip: gboolean);
     pub fn gtk_widget_trigger_tooltip_query    (widget: *mut GtkWidget);
-    //pub fn gtk_widget_get_window               (widget: *mut GtkWidget) -> *mut GtkWindow;
+    pub fn gtk_widget_get_window               (widget: *mut GtkWidget) -> *mut gdk_ffi::GdkWindow;
     //pub fn gtk_widget_register_window          (widget: *mut GtkWidget, window: *mut GtkWindow);
     //pub fn gtk_widget_unregister_window        (widget: *mut GtkWidget, window: *mut GtkWindow);
     //pub fn gtk_cairo_should_draw_window        (cr: *mut cairo_t, window: *mut GtkWindow);

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -360,6 +360,12 @@ pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
         unsafe { to_bool(ffi::gtk_widget_get_double_buffered(self.unwrap_widget())) }
     }
 
+    fn get_window(&self) -> Option<gdk::Window> {
+        unsafe {
+            from_glib_none(ffi::gtk_widget_get_window(self.unwrap_widget()))
+        }
+    }
+
     fn get_has_window(&self) -> bool {
         unsafe { to_bool(ffi::gtk_widget_get_has_window(self.unwrap_widget())) }
     }

--- a/src/traits/window.rs
+++ b/src/traits/window.rs
@@ -6,8 +6,21 @@ use glib::translate::{from_glib_none, ToGlibPtr};
 use ffi;
 use glib::to_gboolean;
 use cast::GTK_WINDOW;
+use gdk;
 
 pub trait WindowTrait : ::WidgetTrait {
+    fn move_(&self, x: i32, y: i32) {
+        unsafe {
+            ffi::gtk_window_move(GTK_WINDOW(self.unwrap_widget()), x, y);
+        }
+    }
+
+    fn set_type_hint(&self, hint: gdk::WindowTypeHint) {
+        unsafe {
+            ffi::gtk_window_set_type_hint(GTK_WINDOW(self.unwrap_widget()), hint);
+        }
+    }
+
     fn set_title(&self, title: &str) -> () {
         unsafe {
             ffi::gtk_window_set_title(GTK_WINDOW(self.unwrap_widget()), title.to_glib_none().0);


### PR DESCRIPTION
Note that `move` was renamed to `move_`, as `move` is a keyword. Adding an underscore has been the trend I've seen in other projects when this name collision happens.