### PR TITLE
Added override_font and wrapped long lines in widget.rs

### DIFF
--- a/gtk-sys/Cargo.toml
+++ b/gtk-sys/Cargo.toml
@@ -22,6 +22,9 @@ gtk_3_10 = []
 gtk_3_12 = []
 gtk_3_14 = []
 
+[dependencies.pango-sys]
+git = "https://github.com/rust-gnome/pango"
+
 [dependencies.gdk-sys]
 git = "https://github.com/rust-gnome/gdk"
 

--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate libc;
 extern crate glib_sys as glib_ffi;
 extern crate gdk_sys as gdk_ffi;
+extern crate pango_sys as pango_ffi;
 
 pub mod enums;
 
@@ -455,7 +456,7 @@ extern "C" {
     //pub fn gtk_widget_input_shape_combine_region(widget: *mut GtkWidget, region: *mut cairo_region_t);
     pub fn gtk_widget_override_background_color(widget: *mut GtkWidget, state: enums::StateFlags, color: *const gdk_ffi::GdkRGBA);
     pub fn gtk_widget_override_color           (widget: *mut GtkWidget, state: enums::StateFlags, color: *const gdk_ffi::GdkRGBA);
-    //pub fn gtk_widget_override_font            (widget: *mut GtkWidget, font_desc: *const PangoFontDescription);
+    pub fn gtk_widget_override_font            (widget: *mut GtkWidget, font_desc: *const pango_ffi::PangoFontDescription);
     pub fn gtk_widget_override_symbolic_color  (widget: *mut GtkWidget, name: *const c_char, color: *const gdk_ffi::GdkRGBA);
     pub fn gtk_widget_override_cursor          (widget: *mut GtkWidget, cursor: *const gdk_ffi::GdkRGBA, secondary_cursor: *const gdk_ffi::GdkRGBA);
     //pub fn gtk_widget_create_pango_context     (widget: *mut GtkWidget) -> *mut PangoContext;

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 use libc::{c_char, c_int};
+use pango;
 use glib::translate::{from_glib_none, from_glib_full, ToGlibPtr};
 use ffi;
 use glib::{to_bool, to_gboolean};
@@ -179,6 +180,10 @@ pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
 
     fn override_cursor(&self, cursor: &gdk_ffi::GdkRGBA, secondary_cursor: &gdk_ffi::GdkRGBA) {
         unsafe { ffi::gtk_widget_override_cursor(self.unwrap_widget(), cursor, secondary_cursor) }
+    }
+
+    fn override_font(&self, font: &pango::FontDescription) {
+        unsafe { ffi::gtk_widget_override_font(self.unwrap_widget(), font.to_glib_none().0) }
     }
 
     fn queue_draw_area(&self, x: i32, y: i32, width: i32, height: i32) {


### PR DESCRIPTION
Adds the `override_font` method now that `FontDescription` is implemented in `pango`. I also wrapped the long lines in widget.rs while I was in there.