### PR TITLE
Add CSS styling support

### DIFF
--- a/gtk-sys/src/enums.rs
+++ b/gtk-sys/src/enums.rs
@@ -1333,11 +1333,11 @@ pub enum TextSearchFlags {
 /// These flags serve two purposes. First, the application can call gtk_places_sidebar_set_open_flags() using these flags as a bitmask. This
 /// tells the sidebar that the application is able to open folders selected from the sidebar in various ways, for example, in new tabs or in
 /// new windows in addition to the normal mode.
-/// 
+///
 /// Second, when one of these values gets passed back to the application in the “open-location” signal, it means that the application should
 /// open the selected location in the normal way, in a new tab, or in a new window. The sidebar takes care of determining the desired way to
 /// open the location, based on the modifier keys that the user is pressing at the time the selection is made.
-/// 
+///
 /// If the application never calls gtk_places_sidebar_set_open_flags(), then the sidebar will only use Normal in the
 /// “open-location” signal. This is the default mode of operation.
 #[repr(C)]

--- a/gtk-sys/src/gtk_glue.c
+++ b/gtk-sys/src/gtk_glue.c
@@ -568,6 +568,10 @@ GtkTextMark* cast_GtkTextMark(GObject* obj) {
     return GTK_TEXT_MARK(obj);
 }
 
+GtkStyleProvider* cast_GtkStyleProvider(GObject* obj) {
+    return GTK_STYLE_PROVIDER(obj);
+}
+
 GtkFileChooserWidget* cast_GtkFileChooserWidget(GtkWidget* widget) {
     return GTK_FILE_CHOOSER_WIDGET(widget);
 }

--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -489,7 +489,7 @@ extern "C" {
     //pub fn gtk_widget_get_settings             (widget: *mut GtkWidget) -> *mut GtkSettings;
     //pub fn gtk_widget_get_clipboard            (widget: *mut GtkWidget, selection: gdk::Atom) -> *mut GtkClipboard;
     //pub fn gtk_widget_get_display              (widget: *mut GtkWidget) -> *mut gdk::Display;
-    //pub fn gtk_widget_get_screen               (widget: *mut GtkWidget) -> *mut gdk::Screen;
+    pub fn gtk_widget_get_screen               (widget: *mut GtkWidget) -> *mut gdk_ffi::GdkScreen;
     pub fn gtk_widget_has_screen               (widget: *mut GtkWidget) -> gboolean;
     pub fn gtk_widget_get_size_request         (widget: *mut GtkWidget, width: *mut c_int, height: *mut c_int);
     pub fn gtk_widget_set_child_visible        (widget: *mut GtkWidget, is_visible: gboolean);

--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -336,6 +336,12 @@ pub struct GtkTooltip;
 
 //pub type GtkTreeModelForeachFunc = fn(model: *mut GtkTreeModel, path: *mut GtkTreePath, iter: *mut GtkTreeIter, data: gpointer) -> gboolean;
 
+pub const GTK_STYLE_PROVIDER_PRIORITY_FALLBACK: u32 = 1;
+pub const GTK_STYLE_PROVIDER_PRIORITY_THEME: u32 = 200;
+pub const GTK_STYLE_PROVIDER_PRIORITY_SETTINGS: u32 = 400;
+pub const GTK_STYLE_PROVIDER_PRIORITY_APPLICATION: u32 = 600;
+pub const GTK_STYLE_PROVIDER_PRIORITY_USER: u32 = 800;
+
 extern "C" {
 
     //=========================================================================

--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -21,6 +21,12 @@ pub use glib_ffi::{
 //pub type GtkAllocation = GdkRectangle;
 
 #[repr(C)]
+pub struct GtkStyleContext;
+#[repr(C)]
+pub struct GtkStyleProvider;
+#[repr(C)]
+pub struct GtkCssProvider;
+#[repr(C)]
 pub struct GtkWidget;
 #[repr(C)]
 pub struct GtkWindow;
@@ -389,6 +395,26 @@ extern "C" {
     pub fn g_type_get_type_registration_serial () -> c_uint;
 
     //=========================================================================
+    // GtkCssProvider                                                    NOT OK
+    //=========================================================================
+
+    pub fn gtk_css_provider_new                () -> *mut GtkCssProvider;
+    pub fn gtk_css_provider_get_default        () -> *mut GtkCssProvider;
+    pub fn gtk_css_provider_get_named          (name: *const c_char, variant: *const c_char) -> *mut GtkCssProvider;
+    pub fn gtk_css_provider_load_from_path     (provider: *mut GtkCssProvider, path: *const c_char, error: *mut *mut GError) -> gboolean;
+    //pub fn gtk_css_provider_load_from_data   (provider: GtkCssProvider, data: *const c_char, length: gssize, error: *mut *mut GError) -> gboolean;
+    //pub fn gtk_css_provider_load_from_file   (provider: *mut GtkCssProvider, file: *const GFile, *mut *mut GError) -> gboolean;
+    //pub fn gtk_css_provider_load_from_resource (provider: *mut GtkCssProvider, resource_path: *const c_char);
+    pub fn gtk_css_provider_to_string          (provider: *mut GtkCssProvider) -> *const c_char;
+
+    //=========================================================================
+    // GtkStyleContext                                                   NOT OK
+    //=========================================================================
+    pub fn gtk_style_context_new                     () -> *mut GtkStyleContext;
+    pub fn gtk_style_context_add_provider            (context: *mut GtkStyleContext, provider: *mut GtkStyleProvider, priority: u32);
+    pub fn gtk_style_context_add_provider_for_screen (screen: *mut gdk_ffi::GdkScreen, provider: *mut GtkStyleProvider, priority: u32);
+
+    //=========================================================================
     // GtkWidget                                                         NOT OK
     //=========================================================================
     //pub fn gtk_widget_new                      (type: GType, first_property_name: *const c_char, ...) -> *mut GtkWidget;
@@ -559,7 +585,7 @@ extern "C" {
     pub fn gtk_widget_get_opacity              (widget: *mut GtkWidget) -> c_double;
     pub fn gtk_widget_set_opacity              (widget: *mut GtkWidget, opacity: c_double);
     //pub fn gtk_widget_get_path                 (widget: *mut GtkWidget) -> *mut GtkWidgetPath;
-    //pub fn gtk_widget_get_style_context        (widget: *mut GtkWidget) -> *mut GtkStyleContext;
+    pub fn gtk_widget_get_style_context        (widget: *mut GtkWidget) -> *mut GtkStyleContext;
     pub fn gtk_widget_reset_style              (widget: *mut GtkWidget);
     //pub fn gtk_requisition_new                 () -> *mut GtkRequisition;
     //pub fn gtk_requisition_copy                (requisition: *const GtkRequisition) -> *mut GtkRequisition;
@@ -3364,4 +3390,5 @@ extern "C" {
     pub fn cast_GtkFontChooserWidget(widget: *mut GtkWidget) -> *mut GtkFontChooserWidget;
     pub fn cast_GtkSocket(widget: *mut GtkWidget) -> *mut GtkSocket;
     pub fn cast_GtkEventBox(widget: *mut GtkWidget) -> *mut GtkEventBox;
+    pub fn cast_GtkStyleProvider(widget: *mut GObject) -> *mut GtkStyleProvider;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@ pub use self::rt::{
 
 /// GTK Widgets for all versions
 pub use self::widgets::{
+    CssProvider,
+    StyleContext,
     Widget,
     Window,
     Label,
@@ -296,6 +298,7 @@ pub use ffi::enums::SizeGroupMode;
 
 /// Gtk Traits
 pub use self::traits::FFIWidget;
+pub use self::traits::StyleProviderTrait;
 pub use self::traits::GObjectTrait;
 pub use self::traits::BoxTrait;
 pub use self::traits::ActionableTrait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ pub use self::rt::{
     events_pending
 };
 
-
 /// GTK Widgets for all versions
 pub use self::widgets::{
     CssProvider,
@@ -340,6 +339,14 @@ pub use self::traits::ToolShellTrait;
 pub use self::traits::WidgetTrait;
 pub use self::traits::WidgetSignals;
 pub use self::traits::WindowTrait;
+
+pub use self::traits::style_provider::{
+    STYLE_PROVIDER_PRIORITY_FALLBACK,
+    STYLE_PROVIDER_PRIORITY_THEME,
+    STYLE_PROVIDER_PRIORITY_SETTINGS,
+    STYLE_PROVIDER_PRIORITY_APPLICATION,
+    STYLE_PROVIDER_PRIORITY_USER
+};
 
 /// GTK various struct
 pub use self::types::{

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -7,6 +7,7 @@ pub trait FFIWidget: Sized {
     fn wrap_widget(widget: *mut ::ffi::GtkWidget) -> Self;
 }
 
+pub use self::style_provider::StyleProviderTrait;
 pub use self::widget::WidgetTrait;
 pub use self::container::ContainerTrait;
 pub use self::window::WindowTrait;
@@ -52,6 +53,7 @@ pub use signal::{
     ToolButtonSignals,
 };
 
+pub mod style_provider;
 pub mod widget;
 pub mod container;
 pub mod window;

--- a/src/traits/style_provider.rs
+++ b/src/traits/style_provider.rs
@@ -2,12 +2,27 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+use ffi;
 use glib::FFIGObject;
 
-pub const PRIORITY_FALLBACK: u32 = 1;
-pub const PRIORITY_THEME: u32 = 200;
-pub const PRIORITY_SETTINGS: u32 = 400;
-pub const PRIORITY_APPLICATION: u32 = 600;
-pub const PRIORITY_USER: u32 = 800;
+/// The priority used for default style information that is used in the absence of themes.
+/// Note that this is not very useful for providing default styling for custom style classes,
+/// themes are likely to override styling provided at this priority with catch-all * {...} rules.
+pub const STYLE_PROVIDER_PRIORITY_FALLBACK: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_FALLBACK;
+
+/// The priority used for style information provided by themes.
+pub const STYLE_PROVIDER_PRIORITY_THEME: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_THEME;
+
+/// The priority used for style information provided via GtkSettings.
+/// This priority is higher than STYLE_PROVIDER_PRIORITY_THEME to let settings override themes.
+pub const STYLE_PROVIDER_PRIORITY_SETTINGS: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_SETTINGS;
+
+/// A priority that can be used when adding a GtkStyleProvider for application-specific style
+/// information.
+pub const STYLE_PROVIDER_PRIORITY_APPLICATION: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_APPLICATION;
+
+/// A priority that can be used when adding a GtkStyleProvider for application-specific style
+/// information.
+pub const STYLE_PROVIDER_PRIORITY_USER: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_USER;
 
 pub trait StyleProviderTrait : FFIGObject {}

--- a/src/traits/style_provider.rs
+++ b/src/traits/style_provider.rs
@@ -1,0 +1,13 @@
+// Copyright 2013-2015, The Rust-GNOME Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use glib::FFIGObject;
+
+pub const PRIORITY_FALLBACK: u32 = 1;
+pub const PRIORITY_THEME: u32 = 200;
+pub const PRIORITY_SETTINGS: u32 = 400;
+pub const PRIORITY_APPLICATION: u32 = 600;
+pub const PRIORITY_USER: u32 = 800;
+
+pub trait StyleProviderTrait : FFIGObject {}

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -236,6 +236,10 @@ pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
         unsafe { to_bool(ffi::gtk_widget_has_screen(self.unwrap_widget())) }
     }
 
+    fn get_screen(&self) -> gdk::Screen {
+        unsafe { from_glib_none(ffi::gtk_widget_get_screen(self.unwrap_widget())) }
+    }
+
     fn get_size_request(&self) -> (i32, i32) {
         let mut width = 0i32;
         let mut height = 0i32;

--- a/src/traits/widget.rs
+++ b/src/traits/widget.rs
@@ -639,6 +639,12 @@ pub trait WidgetTrait: ::FFIWidget + ::GObjectTrait {
         unsafe { ffi::gtk_widget_set_vexpand_set(self.unwrap_widget(), to_gboolean(expand)) }
     }
 
+    fn get_style_context(&self) -> ::StyleContext {
+        unsafe {
+            ::StyleContext { pointer: ffi::gtk_widget_get_style_context(self.unwrap_widget()) }
+        }
+    }
+
     fn queue_compute_expand(&self) {
         unsafe { ffi::gtk_widget_queue_compute_expand(self.unwrap_widget()) }
     }

--- a/src/widgets/css_provider.rs
+++ b/src/widgets/css_provider.rs
@@ -1,0 +1,56 @@
+// Copyright 2013-2015, The Rust-GNOME Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use std::fmt::{self, Display, Formatter};
+use ffi::{self, GtkCssProvider};
+use glib::translate::{ToGlibPtr, from_glib_full};
+use glib::{self, GlibContainer};
+
+#[repr(C)]
+pub struct CssProvider {
+    pointer: *mut GtkCssProvider
+}
+
+impl ::StyleProviderTrait for CssProvider {}
+
+impl CssProvider {
+    pub fn new() -> Self {
+        unsafe { CssProvider { pointer: ffi::gtk_css_provider_new() } }
+    }
+
+    pub fn get_default() -> Self {
+        unsafe { CssProvider { pointer: ffi::gtk_css_provider_get_default() } }
+    }
+
+    pub fn get_named(name: &str, variant: &str) -> Self {
+        unsafe {
+            CssProvider { pointer: ffi::gtk_css_provider_get_named(name.to_glib_none().0,
+                                                                   variant.to_glib_none().0) }
+        }
+    }
+
+    pub fn load_from_path(path: &str) -> Result<CssProvider, glib::Error> {
+        unsafe {
+            let pointer = ffi::gtk_css_provider_new();
+            let mut error = ::std::ptr::null_mut();
+            ffi::gtk_css_provider_load_from_path(pointer, path.to_glib_none().0, &mut error);
+            if error.is_null() {
+                Ok(CssProvider { pointer: pointer })
+            } else {
+                Err(glib::Error::wrap(error))
+            }
+
+        }
+    }
+}
+
+impl Display for CssProvider {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let tmp: String = unsafe { from_glib_full(ffi::gtk_css_provider_to_string(self.pointer)) };
+        write!(f, "{}", tmp)
+    }
+}
+
+impl_GObjectFunctions!(CssProvider, GtkCssProvider);
+impl_TraitObject!(CssProvider, GtkCssProvider);

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -2,6 +2,9 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+pub use self::css_provider::CssProvider;
+pub use self::style_context::StyleContext;
+
 pub use self::widget::Widget;
 pub use self::builder::Builder;
 pub use self::window::Window;
@@ -136,6 +139,9 @@ pub use self::font_chooser_widget::FontChooserWidget;
 #[cfg(target_os = "linux")]
 pub use self::socket::Socket;
 pub use self::event_box::EventBox;
+
+mod css_provider;
+mod style_context;
 
 mod widget;
 mod builder;

--- a/src/widgets/style_context.rs
+++ b/src/widgets/style_context.rs
@@ -1,0 +1,41 @@
+// Copyright 2013-2015, The Rust-GNOME Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use ffi::{self, GtkStyleContext};
+use glib::translate::*;
+use glib::traits::FFIGObject;
+use gdk;
+
+pub struct StyleContext {
+    // FIXME: This doesn't need to be public after object reform lands
+    pub pointer: *mut GtkStyleContext
+}
+
+impl StyleContext {
+    pub fn new() -> Self {
+        unsafe { StyleContext { pointer: ffi::gtk_style_context_new() } }
+    }
+
+    pub fn add_provider<T: ::StyleProviderTrait>(&self, provider: &T, priority: u32) {
+        unsafe {
+            ffi::gtk_style_context_add_provider(
+                self.pointer,
+                ffi::cast_GtkStyleProvider(provider.unwrap_gobject()),
+                priority)
+        };
+    }
+
+    pub fn add_provider_for_screen<T: ::StyleProviderTrait>(screen: &gdk::Screen, provider: &T,
+                                                            priority: u32) {
+        unsafe {
+            ffi::gtk_style_context_add_provider_for_screen(
+                screen.to_glib_none().0,
+                ffi::cast_GtkStyleProvider(provider.unwrap_gobject()),
+                priority)
+        };
+    }
+}
+
+impl_GObjectFunctions!(StyleContext, GtkStyleContext);
+impl_TraitObject!(StyleContext, GtkStyleContext);


### PR DESCRIPTION
This PR adds CSS styling support by implementing `CssProvider`, `StyleProvider`, and `StyleContext`. An approach similar to that used with `WidgetTrait` was taken. `get_screen` is also implemented for `WidgetTrait` so this screen can be used with `StyleContext::add_provider_for_screen`.

There are some TODOs in the code for adding the proper `#![feature]` attributes. The Gtk documentation doesn't give this number for every method/class, and I think this is due to a lack of documentation, not the fact that the method/class was introduced before gtk3. How should I find these feature numbers?