### PR TITLE
Abandon the IterToGlibPtr trait, use slices instead

### DIFF
--- a/src/widgets/about_dialog.rs
+++ b/src/widgets/about_dialog.rs
@@ -2,12 +2,11 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use std::iter::IntoIterator;
 use ffi;
 use glib::{to_bool, to_gboolean};
 use FFIWidget;
 use cast::GTK_ABOUT_DIALOG;
-use glib::translate::{from_glib_none, FromGlibPtrContainer, ToGlibPtr, IterToGlibPtr};
+use glib::translate::{from_glib_none, FromGlibPtrContainer, ToGlibPtr};
 
 struct_Widget!(AboutDialog);
 
@@ -136,8 +135,7 @@ impl AboutDialog {
         }
     }
 
-    pub fn set_authors<'a, S, I: ?Sized>(&self, authors: &'a I)
-    where S: AsRef<str>, &'a I: IntoIterator<Item = &'a S> {
+    pub fn set_authors(&self, authors: &[&str]) {
         unsafe {
             ffi::gtk_about_dialog_set_authors(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
@@ -152,8 +150,7 @@ impl AboutDialog {
         }
     }
 
-    pub fn set_artists<'a, S, I: ?Sized>(&self, artists: &'a I)
-    where S: AsRef<str>, &'a I: IntoIterator<Item = &'a S> {
+    pub fn set_artists(&self, artists: &[&str]) {
         unsafe {
             ffi::gtk_about_dialog_set_artists(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
@@ -168,8 +165,7 @@ impl AboutDialog {
         }
     }
 
-    pub fn set_documenters<'a, S, I: ?Sized>(&self, documenters: &'a I)
-    where S: AsRef<str>, &'a I: IntoIterator<Item = &'a S> {
+    pub fn set_documenters(&self, documenters: &[&str]) {
         unsafe {
             ffi::gtk_about_dialog_set_documenters(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),
@@ -221,8 +217,7 @@ impl AboutDialog {
         };
     }
 
-    pub fn add_credit_section<'a, S, I: ?Sized>(&self, section_name: &str, people: &'a I)
-    where S: AsRef<str>, &'a I: IntoIterator<Item = &'a S> {
+    pub fn add_credit_section(&self, section_name: &str, people: &[&str]) {
         unsafe {
             ffi::gtk_about_dialog_add_credit_section(
                 GTK_ABOUT_DIALOG(self.unwrap_widget()),

--- a/src/widgets/recent_data.rs
+++ b/src/widgets/recent_data.rs
@@ -4,7 +4,7 @@
 
 use ffi;
 use libc::c_char;
-use glib::translate::{ToGlib, ToGlibPtr, IterToGlibPtr, Stash, IterStash};
+use glib::translate::{ToGlib, ToGlibPtr, Stash};
 
 pub struct RecentData {
     display_name: String,
@@ -16,10 +16,10 @@ pub struct RecentData {
     is_private: bool
 }
 
-impl <'a> ToGlibPtr<'a, *mut ffi::GtkRecentData> for &'a RecentData {
+impl<'a> ToGlibPtr<'a, *mut ffi::GtkRecentData> for &'a RecentData {
     type Storage = (Box<ffi::GtkRecentData>,
                     [Stash<'a, *const c_char, String>; 5],
-                    IterStash<'a, *mut *const c_char, Vec<String>>);
+                    Stash<'a, *mut *const c_char, &'a [String]>);
 
     fn to_glib_none(&self)
         -> Stash<'a, *mut ffi::GtkRecentData, &'a RecentData> {
@@ -28,7 +28,7 @@ impl <'a> ToGlibPtr<'a, *mut ffi::GtkRecentData> for &'a RecentData {
         let mime_type = self.mime_type.to_glib_none();
         let app_name = self.app_name.to_glib_none();
         let app_exec = self.app_exec.to_glib_none();
-        let groups = self.groups.to_glib_none();
+        let groups = (&*self.groups).to_glib_none();
 
         let mut data = Box::new(ffi::GtkRecentData {
             display_name: display_name.0 as *mut c_char,


### PR DESCRIPTION
IterToGlibPtr was an attempt to work around the conflicting blanket implementations problem but it appears to be insufficient.
Until the sys crates learn to specify the container types more precisely, we'll have to live without generic impls.