### PR TITLE
Readme: update Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ __gtk__ expects __GTK+__, __GLib__ and __Cairo__ development files to be install
 ### Fedora
 
 ```Shell
+> sudo dnf install gtk3-devel glib2-devel
+
+# Fedora 21 and earlier
 > sudo yum install gtk3-devel glib2-devel
 ```
 


### PR DESCRIPTION
They have changed their default package manager to `dnf` since Release 22 :-(

I'm not sure if this should still mention `yum` by splitting the instructions between Fedora <= 21 and Fedora >= 22.