### PR TITLE
Replace features with cfg and automatic version detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gtk"
 version = "0.0.3"
 authors = ["The Rust-GNOME Project Developers"]
+build = "build.rs"
 
 description = "Rust bindings for the GTK+ library"
 repository = "https://github.com/rust-gnome/gtk"
@@ -17,13 +18,12 @@ keywords = ["gtk", "gnome", "GUI"]
 name = "gtk"
 
 [features]
-default = ["gtk_3_6"]
-gtk_3_4 = ["gtk-sys/gtk_3_4", "gdk/gdk_3_4"]
-gtk_3_6 = ["gtk-sys/gtk_3_6", "gdk/gdk_3_6", "gtk_3_4"]
-gtk_3_8 = ["gtk-sys/gtk_3_8", "gdk/gdk_3_8", "gtk_3_6"]
-gtk_3_10 = ["gtk-sys/gtk_3_10", "gdk/gdk_3_10", "cairo-rs/cairo_1_12", "gtk_3_8"]
-gtk_3_12 = ["gtk-sys/gtk_3_12", "gdk/gdk_3_12", "gtk_3_10"]
-gtk_3_14 = ["gtk-sys/gtk_3_14", "gdk/gdk_3_14", "gtk_3_12"]
+gtk_3_4 = []
+gtk_3_6 = []
+gtk_3_8 = []
+gtk_3_10 = ["cairo-rs/cairo_1_12"]
+gtk_3_12 = ["gtk_3_10"]
+gtk_3_14 = ["gtk_3_12"]
 
 [dependencies.gdk-sys]
 git = "https://github.com/rust-gnome/gdk"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    let cfgs = env::var("OVERRIDE_GTK_CFG")
+        .or_else(|_| env::var("DEP_GTK_CFG"))
+        .unwrap_or_else(|e| panic!("Failed to read `DEP_GTK_CFG`: {}", e));
+    for cfg in cfgs.split(' ') {
+        println!("cargo:rustc-cfg={}", cfg);
+    }
+}

--- a/gtk-sys/Cargo.toml
+++ b/gtk-sys/Cargo.toml
@@ -14,14 +14,6 @@ documentation = "https://github.com/rust-gnome/gtk"
 [lib]
 name = "gtk_sys"
 
-[features]
-gtk_3_4 = []
-gtk_3_6 = []
-gtk_3_8 = []
-gtk_3_10 = []
-gtk_3_12 = []
-gtk_3_14 = []
-
 [dependencies.glib-sys]
 git = "https://github.com/rust-gnome/glib"
 
@@ -35,5 +27,5 @@ git = "https://github.com/rust-gnome/pango"
 libc = "0.1"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.5"
 gcc = "0.3"

--- a/gtk-sys/build.rs
+++ b/gtk-sys/build.rs
@@ -5,19 +5,39 @@
 extern crate gcc;
 extern crate pkg_config;
 
+use std::ascii::AsciiExt;
 use std::process::Command;
 use gcc::Config;
 use std::env;
 use std::path::Path;
 
-fn main() {
-    env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
+const MIN_MAJOR: u16 = 3;
+const MIN_MINOR: u16 = 4;
+const MINOR_STEP: u16 = 2;
 
-    // try to find gtk+-3.0 library
-    match pkg_config::find_library("gtk+-3.0") {
-        Ok(_) => {},
-        Err(e) => panic!("{}", e)
-    };
+fn main() {
+    let lib = pkg_config::find_library("gtk+-3.0")
+        .unwrap_or_else(|e| panic!("{}", e));
+    let mut parts = lib.version.splitn(3, '.')
+        .map(|s| s.parse())
+        .take_while(|r| r.is_ok())
+        .map(|r| r.unwrap());
+    let version: (u16, u16) = (parts.next().unwrap_or(0), parts.next().unwrap_or(0));
+    let mut cfgs = Vec::new();
+    if version.0 == MIN_MAJOR && version.1 > MIN_MINOR {
+        let major = version.0;
+        let mut minor = MIN_MINOR + MINOR_STEP;
+        while minor <= version.1 {
+            cfgs.push(format!("gtk_{}_{}", major, minor));
+            minor += MINOR_STEP;
+        }
+    }
+    for cfg in &cfgs {
+        println!("cargo:rustc-cfg={}", cfg);
+    }
+    println!("cargo:cfg={}", cfgs.connect(" "));
+
+    env::set_var("PKG_CONFIG_ALLOW_CROSS", "1");
 
     // call native pkg-config, there is no way to do this with pkg-config for now
     let cmd = Command::new("pkg-config").arg("--cflags").arg("gtk+-3.0")
@@ -40,15 +60,8 @@ fn main() {
     gcc_conf.file("src/gtk_glue.c");
 
     // pass the GTK feature flags
-    for (key, _) in env::vars() {
-        if key.starts_with("CARGO_FEATURE_") {
-            let feature = key.trim_left_matches("CARGO_FEATURE_");
-            if feature.starts_with("GTK_") {
-                let mut flag = String::from("-D");
-                flag.push_str(feature);
-                gcc_conf.flag(&flag);
-            }
-        }
+    for cfg in &cfgs {
+        gcc_conf.flag(&format!("-D{}", cfg.to_ascii_uppercase()));
     }
 
     // build library

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -130,7 +130,7 @@ pub fn GTK_LEVELBAR(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkLevelBar {
     unsafe { ffi::cast_GtkLevelBar(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_SEARCHBAR(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkSearchBar {
     unsafe { ffi::cast_GtkSearchBar(widget) }
 }
@@ -231,17 +231,17 @@ pub fn GTK_NOTEBOOK(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkNotebook {
     unsafe { ffi::cast_GtkNotebook(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_STACK(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkStack {
     unsafe { ffi::cast_GtkStack(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_STACK_SWITCHER(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkStackSwitcher {
     unsafe { ffi::cast_GtkStackSwitcher(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_REVEALER(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkRevealer {
     unsafe { ffi::cast_GtkRevealer(widget) }
 }
@@ -258,32 +258,32 @@ pub fn GTK_LAYOUT(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkLayout {
     unsafe { ffi::cast_GtkLayout(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_HEADER_BAR(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkHeaderBar {
     unsafe { ffi::cast_GtkHeaderBar(widget) }
 }
 
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub fn GTK_FLOW_BOX(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkFlowBox {
     unsafe { ffi::cast_GtkFlowBox(widget) }
 }
 
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub fn GTK_FLOW_BOX_CHILD(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkFlowBoxChild {
     unsafe { ffi::cast_GtkFlowBoxChild(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_LIST_BOX(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkListBox {
     unsafe { ffi::cast_GtkListBox(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_LIST_BOX_ROW(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkListBoxRow {
     unsafe { ffi::cast_GtkListBoxRow(widget) }
 }
 
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub fn GTK_ACTION_BAR(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkActionBar {
     unsafe { ffi::cast_GtkActionBar(widget) }
 }
@@ -484,7 +484,7 @@ pub fn GTK_COMBO_BOX(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkComboBox {
     unsafe { ffi::cast_GtkComboBox(widget) }
 }
 
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub fn GTK_POPOVER(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkPopover {
     unsafe { ffi::cast_GtkPopover(widget) }
 }
@@ -501,7 +501,7 @@ pub fn GTK_TEXT_MARK(widget: *mut ::glib::ffi::GObject) -> *mut ffi::GtkTextMark
     unsafe { ffi::cast_GtkTextMark(widget) }
 }
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub fn GTK_PLACES_SIDEBAR(widget: *mut ffi::GtkWidget) -> *mut ffi::GtkPlacesSidebar {
     unsafe { ffi::cast_GtkPlacesSidebar(widget) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,14 +182,14 @@ pub use self::widgets::{
 #[cfg(target_os = "linux")]
 pub use self::widgets::{Socket};
 
-#[cfg(feature = "gtk_3_6")]
+#[cfg(gtk_3_6)]
 /// GTK Widgets for versions since GTK 3.6
 pub use self::widgets::{
     MenuButton,
     LevelBar,
 };
 
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 /// GTK Widgets for versions since GTK 3.10
 pub use self::widgets::{
     SearchEntry,
@@ -203,7 +203,7 @@ pub use self::widgets::{
     PlacesSidebar
 };
 
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 /// GTK Widgets for versions since GTK 3.12
 pub use self::widgets::{
     FlowBox,

--- a/src/traits/button.rs
+++ b/src/traits/button.rs
@@ -122,12 +122,12 @@ pub trait ButtonTrait: ::WidgetTrait + ::ContainerTrait {
         }
     }
 
-    #[cfg(feature = "gtk_3_6")]
+    #[cfg(gtk_3_6)]
     fn set_always_show_image(&self, always_show: bool) -> () {
         unsafe { ffi::gtk_button_set_always_show_image(GTK_BUTTON(self.unwrap_widget()), to_gboolean(always_show)); }
     }
 
-    #[cfg(feature = "gtk_3_6")]
+    #[cfg(gtk_3_6)]
     fn get_always_show_image(&self) -> bool {
         unsafe { to_bool(ffi::gtk_button_get_always_show_image(GTK_BUTTON(self.unwrap_widget()))) }
     }

--- a/src/traits/dialog.rs
+++ b/src/traits/dialog.rs
@@ -246,7 +246,7 @@ pub trait DialogTrait: ::WidgetTrait + ::ContainerTrait + ::BinTrait + ::WindowT
         }
     }
 
-    #[cfg(feature = "gtk_3_12")]
+    #[cfg(gtk_3_12)]
     fn get_header_bar<T: ::WidgetTrait>(&self) -> Option<T> {
         let tmp_pointer = unsafe { ffi::gtk_dialog_get_header_bar(GTK_DIALOG(self.unwrap_widget())) };
 

--- a/src/traits/label.rs
+++ b/src/traits/label.rs
@@ -73,14 +73,14 @@ pub trait LabelTrait: ::WidgetTrait {
         unsafe { to_bool(ffi::gtk_label_get_line_wrap(GTK_LABEL(self.unwrap_widget()))) }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     fn set_lines(&self, lines: i32) -> () {
         unsafe {
             ffi::gtk_label_set_lines(GTK_LABEL(self.unwrap_widget()), lines as c_int);
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     fn get_lines(&self) -> i32 {
         unsafe {
             ffi::gtk_label_get_lines(GTK_LABEL(self.unwrap_widget())) as c_int

--- a/src/traits/window.rs
+++ b/src/traits/window.rs
@@ -51,7 +51,7 @@ pub trait WindowTrait : ::WidgetTrait {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     fn set_titlebar<T: ::WidgetTrait>(&self, titlebar: &T) {
         unsafe {
             ffi::gtk_window_set_titlebar(GTK_WINDOW(self.unwrap_widget()), titlebar.unwrap_widget());

--- a/src/widgets/builder.rs
+++ b/src/widgets/builder.rs
@@ -2,7 +2,7 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-#![cfg_attr(not(feature = "gtk_3_10"), allow(unused_imports))]
+#![cfg_attr(not(gtk_3_10), allow(unused_imports))]
 
 use ffi::{self, GtkBuilder};
 use libc::{c_char, c_long};
@@ -27,7 +27,7 @@ impl Builder {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn new_from_file(file_name: &str) -> Option<Builder> {
         let tmp = unsafe {
             ffi::gtk_builder_new_from_file(file_name.to_glib_none().0)
@@ -42,7 +42,7 @@ impl Builder {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn new_from_resource(resource_path: &str) -> Option<Builder> {
         let tmp = unsafe {
             ffi::gtk_builder_new_from_resource(resource_path.to_glib_none().0)
@@ -57,7 +57,7 @@ impl Builder {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn new_from_string(string: &str) -> Option<Builder> {
         let tmp = unsafe {
             // Don't need a null-terminated string here

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -6,7 +6,7 @@
 
 use ffi;
 use glib::translate::ToGlibPtr;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 use IconSize;
 
 /**
@@ -43,7 +43,7 @@ impl Button {
         check_pointer!(tmp_pointer, Button)
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn new_from_icon_name(icon_name: &str, size: IconSize) -> Option<Button> {
         let tmp_pointer = unsafe {
             ffi::gtk_button_new_from_icon_name(icon_name.to_glib_none().0, size)

--- a/src/widgets/grid.rs
+++ b/src/widgets/grid.rs
@@ -66,14 +66,14 @@ impl Grid {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
      pub fn remove_row(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_grid_remove_row(GTK_GRID(self.pointer), position as c_int);
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
      pub fn remove_column(&self, position: i32) -> () {
         unsafe {
             ffi::gtk_grid_remove_column(GTK_GRID(self.pointer), position as c_int);
@@ -126,14 +126,14 @@ impl Grid {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn get_baseline_row(&self) -> i32 {
         unsafe {
             ffi::gtk_grid_get_baseline_row(GTK_GRID(self.pointer)) as i32
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn set_baseline_row(&self, row: i32) -> () {
         unsafe {
             ffi::gtk_grid_set_baseline_row(GTK_GRID(self.pointer), row as c_int);

--- a/src/widgets/icon_view.rs
+++ b/src/widgets/icon_view.rs
@@ -177,12 +177,12 @@ impl IconView {
         unsafe { ffi::gtk_icon_view_get_item_padding(GTK_ICON_VIEW(self.pointer)) }
     }
 
-    #[cfg(feature = "gtk_3_8")]
+    #[cfg(gtk_3_8)]
     pub fn set_activate_on_single_click(&self, single: bool) {
         unsafe { ffi::gtk_icon_view_set_activate_on_single_click(GTK_ICON_VIEW(self.pointer), if single == false {0} else {1}) }
     }
 
-    #[cfg(feature = "gtk_3_8")]
+    #[cfg(gtk_3_8)]
     pub fn get_activate_on_single_click(&self) -> bool {
         match unsafe { ffi::gtk_icon_view_get_activate_on_single_click(GTK_ICON_VIEW(self.pointer)) } {
             0 => false,

--- a/src/widgets/info_bar.rs
+++ b/src/widgets/info_bar.rs
@@ -4,7 +4,7 @@
 
 //! Report important messages to the user
 
-#![cfg_attr(not(feature = "gtk_3_10"), allow(unused_imports))]
+#![cfg_attr(not(gtk_3_10), allow(unused_imports))]
 
 use libc::c_int;
 use glib::translate::ToGlibPtr;
@@ -64,12 +64,12 @@ impl InfoBar {
         }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn show_close_button(&self, show: bool) -> () {
          unsafe { ffi::gtk_info_bar_set_show_close_button(GTK_INFOBAR(self.pointer), to_gboolean(show)); }
     }
 
-    #[cfg(feature = "gtk_3_10")]
+    #[cfg(gtk_3_10)]
     pub fn get_show_close_button(&self) -> bool {
         unsafe { to_bool(ffi::gtk_info_bar_get_show_close_button(GTK_INFOBAR(self.pointer))) }
     }

--- a/src/widgets/level_bar.rs
+++ b/src/widgets/level_bar.rs
@@ -4,7 +4,7 @@
 
 //! A bar that can used as a level indicator
 
-#![cfg_attr(not(feature = "gtk_3_8"), allow(unused_imports))]
+#![cfg_attr(not(gtk_3_8), allow(unused_imports))]
 
 use libc::c_double;
 use glib::translate::ToGlibPtr;
@@ -80,12 +80,12 @@ impl LevelBar {
         }
     }
 
-    #[cfg(feature = "gtk_3_8")]
+    #[cfg(gtk_3_8)]
     pub fn set_inverted(&self, inverted: bool) -> () {
         unsafe { ffi::gtk_level_bar_set_inverted(GTK_LEVELBAR(self.pointer), to_gboolean(inverted)); }
     }
 
-    #[cfg(feature = "gtk_3_8")]
+    #[cfg(gtk_3_8)]
     pub fn get_inverted(&self) -> bool {
         unsafe { to_bool(ffi::gtk_level_bar_get_inverted(GTK_LEVELBAR(self.pointer))) }
     }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -20,7 +20,7 @@ pub use self::font_button::FontButton;
 pub use self::toggle_button::ToggleButton;
 pub use self::check_button::CheckButton;
 pub use self::font_chooser_dialog::FontChooserDialog;
-#[cfg(feature = "gtk_3_6")]
+#[cfg(gtk_3_6)]
 pub use self::menu_button::MenuButton;
 pub use self::color_button::ColorButton;
 pub use self::link_button::LinkButton;
@@ -30,14 +30,14 @@ pub use self::volume_button::VolumeButton;
 pub use self::grid::Grid;
 pub use self::entry_buffer::EntryBuffer;
 pub use self::entry::Entry;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::search_entry::SearchEntry;
 pub use self::switch::Switch;
 pub use self::range::Range;
 pub use self::scale::Scale;
-#[cfg(feature = "gtk_3_6")]
+#[cfg(gtk_3_6)]
 pub use self::level_bar::LevelBar;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::search_bar::SearchBar;
 pub use self::spin_button::SpinButton;
 pub use self::spinner::Spinner;
@@ -65,21 +65,21 @@ pub use self::about_dialog::AboutDialog;
 pub use self::message_dialog::MessageDialog;
 pub use self::color_chooser_dialog::ColorChooserDialog;
 pub use self::note_book::NoteBook;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::stack::Stack;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::stack_switcher::StackSwitcher;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::revealer::Revealer;
 pub use self::overlay::Overlay;
 pub use self::layout::Layout;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::header_bar::HeaderBar;
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub use self::flow_box::{FlowBox, FlowBoxChild};
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::list_box::{ListBox, ListBoxRow};
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub use self::action_bar::ActionBar;
 pub use self::file_filter::FileFilter;
 pub use self::file_chooser_dialog::FileChooserDialog;
@@ -118,7 +118,7 @@ pub use self::icon_view::IconView;
 pub use self::tree_selection::TreeSelection;
 pub use self::recent_chooser_widget::RecentChooserWidget;
 pub use self::combo_box::ComboBox;
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 pub use self::popover::Popover;
 pub use self::combo_box_text::ComboBoxText;
 //pub use self::gtype::g_type;
@@ -127,7 +127,7 @@ pub use self::text_tag::TextTag;
 pub use self::text_attributes::TextAttributes;
 pub use self::text_iter::TextIter;
 pub use self::text_child_anchor::TextChildAnchor;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 pub use self::places_sidebar::PlacesSidebar;
 pub use self::tool_palette::ToolPalette;
 pub use self::tool_item_group::ToolItemGroup;
@@ -157,7 +157,7 @@ mod separator;
 mod font_button;
 mod toggle_button;
 mod check_button;
-#[cfg(feature = "gtk_3_6")]
+#[cfg(gtk_3_6)]
 mod menu_button;
 mod color_button;
 mod link_button;
@@ -167,14 +167,14 @@ mod volume_button;
 mod grid;
 mod entry_buffer;
 mod entry;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod search_entry;
 mod switch;
 mod range;
 mod scale;
-#[cfg(feature = "gtk_3_6")]
+#[cfg(gtk_3_6)]
 mod level_bar;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod search_bar;
 mod spin_button;
 mod spinner;
@@ -198,21 +198,21 @@ mod color_chooser_dialog;
 mod font_chooser_dialog;
 mod message_dialog;
 mod note_book;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod stack;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod stack_switcher;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod revealer;
 mod overlay;
 mod layout;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod header_bar;
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 mod flow_box;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod list_box;
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 mod action_bar;
 mod file_filter;
 mod file_chooser_dialog;
@@ -256,7 +256,7 @@ mod icon_view;
 mod tree_selection;
 mod recent_chooser_widget;
 mod combo_box;
-#[cfg(feature = "gtk_3_12")]
+#[cfg(gtk_3_12)]
 mod popover;
 mod combo_box_text;
 //mod gtype;
@@ -265,7 +265,7 @@ mod text_tag;
 mod text_attributes;
 mod text_iter;
 mod text_child_anchor;
-#[cfg(feature = "gtk_3_10")]
+#[cfg(gtk_3_10)]
 mod places_sidebar;
 mod tool_palette;
 mod tool_item_group;

--- a/src/widgets/tree_path.rs
+++ b/src/widgets/tree_path.rs
@@ -37,7 +37,7 @@ impl TreePath {
         }
     }
 
-    #[cfg(feature = "gtk_3_12")]
+    #[cfg(gtk_3_12)]
     pub fn new_from_indicesv(indices: &mut [i32]) -> Option<TreePath> {
         let tmp = unsafe { ffi::gtk_tree_path_new_from_indicesv(indices.as_mut_ptr(), indices.len() as ::libc::c_ulong) };
 

--- a/src/widgets/tree_view.rs
+++ b/src/widgets/tree_view.rs
@@ -71,14 +71,14 @@ impl TreeView {
         }
     }
 
-    #[cfg(feature = "gtk_3_8")]
+    #[cfg(gtk_3_8)]
     pub fn get_activate_on_single_click(&self) -> bool {
         unsafe {
             to_bool(ffi::gtk_tree_view_get_activate_on_single_click(GTK_TREE_VIEW(self.pointer)))
         }
     }
 
-    #[cfg(feature = "gtk_3_8")]
+    #[cfg(gtk_3_8)]
     pub fn set_activate_on_single_click(&self, setting: bool) {
         unsafe {
             ffi::gtk_tree_view_set_activate_on_single_click(GTK_TREE_VIEW(self.pointer),


### PR DESCRIPTION
The user is no longer required to set the target library version, the builds script detects it from `pkg-config` output and sets the appropriate `cfg` directives.