### PR TITLE
Fix the gcc version to avoid dependency creep

### DIFF
--- a/gtk-sys/Cargo.toml
+++ b/gtk-sys/Cargo.toml
@@ -28,4 +28,4 @@ libc = "0.1"
 
 [build-dependencies]
 pkg-config = "0.3.5"
-gcc = "0.3"
+gcc = "=0.3.9"


### PR DESCRIPTION
The newer versions depend on winapi on Windows, requiring Rust 1.1.